### PR TITLE
Add release task and pipeline

### DIFF
--- a/pipelines/release.yaml
+++ b/pipelines/release.yaml
@@ -1,0 +1,213 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: calunga-push-to-pulp
+spec:
+  description: >-
+    Release Components in a Snapshot to a pulp-backed python index. Each image in a Component is
+    expected to contain a python wheel and sdist under the /releases directory.
+  params:
+    - name: release
+      type: string
+      description:
+        The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution
+    - name: releasePlan
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlan
+    - name: releasePlanAdmission
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlanAdmission
+    - name: releaseServiceConfig
+      type: string
+      description: The namespaced name (namespace/name) of the releaseServiceConfig
+    - name: snapshot
+      type: string
+      description: The namespaced name (namespace/name) of the snapshot
+    - name: enterpriseContractPolicy
+      type: string
+      description: JSON representation of the EnterpriseContractPolicy
+    - name: enterpriseContractExtraRuleData
+      type: string
+      description: |
+        Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax
+        "key1=value1,key2=value2..."
+      default: "pipeline_intention=release"
+    - name: enterpriseContractTimeout
+      type: string
+      description: Timeout setting for `ec validate`
+      default: 40m0s
+    - name: verify_ec_task_bundle
+      type: string
+      description: The location of the bundle containing the verify-enterprise-contract task
+    - name: verify_ec_task_git_revision
+      type: string
+      description: The git revision to be used when consuming the verify-conforma task
+    - name: taskGitUrl
+      type: string
+      description: >-
+        The url to the git repo where the release-service-catalog tasks to be used are stored.
+        This is currently ignored.
+      default: https://github.com/lcarva/calunga.git
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used. This is currently ignored.
+    # TODO: Some of these should probably come from the RP or RPA.
+    - name: pulpBaseUrl
+      type: string
+      default: https://mtls.internal.console.redhat.com
+    - name: pulpDomain
+      type: string
+      default: public-calunga
+    - name: pulpApiRoot
+      type: string
+      default: "/api/pulp/"
+    - name: pulpSecretName
+      type: string
+      default: pulp-credentials
+    - name: pulpRepository
+      type: string
+      default: mypypi
+    - name: config
+      description: Name of the ConfigMap with config options, e.g. ociStorage
+      type: string
+      default: release-pipeline-config
+  tasks:
+
+    - name: config
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/calungaproject/plumbing.git
+          - name: revision
+            # TODO: Update to main
+            value: add-release-task-pipeline
+          - name: pathInRepo
+            value: tasks/get-config.yaml
+      params:
+        - name: configMapName
+          value: $(params.config)
+
+    - name: collect-data
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/release-service-catalog.git
+          - name: revision
+            value: production
+          - name: pathInRepo
+            value: tasks/managed/collect-data/collect-data.yaml
+      params:
+        - name: release
+          value: $(params.release)
+        - name: releasePlan
+          value: $(params.releasePlan)
+        - name: releasePlanAdmission
+          value: $(params.releasePlanAdmission)
+        - name: releaseServiceConfig
+          value: $(params.releaseServiceConfig)
+        - name: snapshot
+          value: $(params.snapshot)
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
+        - name: taskGitRevision
+          value: "production"
+        - name: ociStorage
+          value: $(tasks.config.results.ociStorage)
+
+    # TODO: We probably don't need to support single component mode.
+    - name: reduce-snapshot
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/release-service-catalog.git
+          - name: revision
+            value: production
+          - name: pathInRepo
+            value: tasks/managed/reduce-snapshot/reduce-snapshot.yaml
+      params:
+        - name: SNAPSHOT
+          value: $(workspaces.data.path)/$(tasks.collect-data.results.snapshotSpec)
+        - name: SINGLE_COMPONENT
+          value: $(tasks.collect-data.results.singleComponentMode)
+        - name: SINGLE_COMPONENT_CUSTOM_RESOURCE
+          value: snapshot/$(tasks.collect-data.results.snapshotName)
+        - name: SINGLE_COMPONENT_CUSTOM_RESOURCE_NS
+          value: $(tasks.collect-data.results.snapshotNamespace)
+        - name: SNAPSHOT_PATH
+          value: $(workspaces.data.path)/$(tasks.collect-data.results.snapshotSpec)
+        - name: taskGitUrl
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
+        - name: taskGitRevision
+          value: "production"
+        - name: sourceDataArtifact
+          value: "$(tasks.collect-data.results.sourceDataArtifact)"
+        - name: ociStorage
+          value: $(tasks.config.results.ociStorage)
+      runAfter:
+        - collect-data
+
+    - name: verify-enterprise-contract
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/enterprise-contract/ec-cli
+          - name: revision
+            # TODO: How to keep this up to date?
+            value: cdfd9188f9352d7269ae1fe8c273a9e67f60ab8a
+          - name: pathInRepo
+            value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
+      params:
+        - name: SNAPSHOT_FILENAME
+          value: "$(tasks.collect-data.results.snapshotSpec)"
+        - name: SSL_CERT_DIR
+          value: /var/run/secrets/kubernetes.io/serviceaccount
+        - name: POLICY_CONFIGURATION
+          value: $(params.enterpriseContractPolicy)
+        - name: STRICT
+          value: "true"
+        - name: IGNORE_REKOR
+          value: "true"
+        - name: EXTRA_RULE_DATA
+          value: $(params.enterpriseContractExtraRuleData)
+        - name: TIMEOUT
+          value: $(params.enterpriseContractTimeout)
+        - name: SOURCE_DATA_ARTIFACT
+          value: "$(tasks.reduce-snapshot.results.sourceDataArtifact)"
+      runAfter:
+        - reduce-snapshot
+
+    - name: push-py-pulp
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/calungaproject/plumbing.git
+          - name: revision
+            # TODO: Update to main
+            value: add-release-task-pipeline
+          - name: pathInRepo
+            value: tasks/push-py-pulp.yaml
+      params:
+        - name: SNAPSHOT_PATH
+          value: $(tasks.collect-data.results.snapshotSpec)
+        - name: PULP_BASE_URL
+          value: $(params.pulpBaseUrl)
+        - name: PULP_API_ROOT
+          value: $(params.pulpApiRoot)
+        - name: PULP_DOMAIN
+          value: $(params.pulpDomain)
+        - name: PULP_SECRET_NAME
+          value: $(params.pulpSecretName)
+        - name: PULP_REPOSITORY
+          value: $(params.pulpRepository)
+        - name: sourceDataArtifact
+          value: "$(tasks.reduce-snapshot.results.sourceDataArtifact)"
+      runAfter:
+        - verify-enterprise-contract

--- a/tasks/get-config.yaml
+++ b/tasks/get-config.yaml
@@ -1,0 +1,32 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: get-config
+spec:
+  description: |
+    Expose values of the release pipeline ConfigMap as Tekton results
+  params:
+    - name: configMapName
+      type: string
+      description: Name of the ConfigMap
+  results:
+    - name: ociStorage
+      type: string
+  volumes:
+    - name: release-pipeline-config
+      configMap:
+        name: $(params.configMapName)
+  stepTemplate:
+    volumeMounts:
+      - name: release-pipeline-config
+        mountPath: /etc/release-pipeline-config
+        readOnly: true
+  steps:
+    - name: map-config
+      image: registry.access.redhat.com/ubi10/ubi:latest
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        ls -la /etc/release-pipeline-config
+        cp /etc/release-pipeline-config/ociStorage "$(results.ociStorage.path)"

--- a/tasks/push-py-pulp.yaml
+++ b/tasks/push-py-pulp.yaml
@@ -1,0 +1,105 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: push-py-pulp
+spec:
+  description: |
+    Push Python packages from an OCI artifact to a Pulp repository.
+  params:
+    - name: SNAPSHOT_PATH
+      type: string
+      description: Path to the snapshot spec file containing image information
+    - name: PULP_SECRET_NAME
+      type: string
+      description: >-
+        The name of the secret containing the Pulp credentials. It must have the cert and key data
+        attributes.
+      default: pulp-credentials
+    - name: PULP_BASE_URL
+      type: string
+      description: The base URL of the Pulp server
+    - name: PULP_API_ROOT
+      type: string
+      description: The API root path of the Pulp server
+      default: "/api/pulp/"
+    - name: PULP_DOMAIN
+      type: string
+      description: The domain to use for Pulp operations
+    - name: PULP_REPOSITORY
+      type: string
+    - name: sourceDataArtifact
+      type: string
+      description: Trusted Artifact to use to obtain the Snapshot
+    - name: TRUSTED_ARTIFACTS_EXTRACT_DIR
+      description: Directory to use to extract trusted artifact archive.
+      type: string
+      # need to specify a subfolder during the extract to avoid the error:
+      # tar: .: Cannot change mode to rwxr-sr-x: Operation not permitted
+      default: "/var/workdir/ta"
+  volumes:
+    - name: pulp-secret
+      secret:
+        secretName: $(params.PULP_SECRET_NAME)
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    env:
+      - name: SNAPSHOT_PATH
+        value: $(params.SNAPSHOT_PATH)
+      - name: PULP_BASE_URL
+        value: $(params.PULP_BASE_URL)
+      - name: PULP_API_ROOT
+        value: $(params.PULP_API_ROOT)
+      - name: PULP_DOMAIN
+        value: $(params.PULP_DOMAIN)
+      - name: PULP_REPOSITORY
+        value: $(params.PULP_REPOSITORY)
+      - name: IMAGES_TXT
+        value: /var/workdir/images.txt
+      - name: FILES_DIR
+        value: /var/workdir/files
+      - name: TRUSTED_ARTIFACTS_EXTRACT_DIR
+        value: $(params.TRUSTED_ARTIFACTS_EXTRACT_DIR)
+    volumeMounts:
+      - name: pulp-secret
+        mountPath: "/etc/pulp-secret"
+        readOnly: true
+      - name: workdir
+        mountPath: "/var/workdir"
+    workingDir: "/var/workdir"
+  steps:
+    - name: use-trusted-artifact
+      args:
+        - use
+        - $(params.sourceDataArtifact)=$(params.TRUSTED_ARTIFACTS_EXTRACT_DIR)
+      computeResources: {}
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:e02102ede09aa07187cba066ad547a54724e5cf4
+    - name: get-image-urls
+      image: quay.io/konflux-ci/buildah-task:latest@sha256:b82d465a06c926882d02b721cf8a8476048711332749f39926a01089cf85a3f9
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        < "${TRUSTED_ARTIFACTS_EXTRACT_DIR}/${SNAPSHOT_PATH}" jq -r '.components[].containerImage' | tee "${IMAGES_TXT}"
+
+    - name: extract-artifacts
+      image: quay.io/konflux-ci/oras:latest@sha256:1beeecce012c99794568f74265c065839f9703d28306a8430b667f639343a98b
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        AUTHFILE='/tmp/auth.json'
+        mkdir -p "${FILES_DIR}"
+        while read -r IMAGE; do
+          echo "Processing ${IMAGE}"
+          select-oci-auth "${IMAGE}" > "${AUTHFILE}"
+          retry oras pull --registry-config "${AUTHFILE}" "${IMAGE}" -o "${FILES_DIR}"
+        done < "${IMAGES_TXT}"
+
+        ls -la "${FILES_DIR}"
+
+    # TODO: Use nudging to keep this up to date.
+    - name: upload
+      image: quay.io/redhat-user-workloads/calunga-tenant/plumbing-utils@sha256:5e154f2f21a881f6a17d8588b8c2ad0a048370d205a3a222dcf59d6af41f5f58
+      command:
+        - pulp-upload


### PR DESCRIPTION
## Summary by Sourcery

Implement a Tekton release pipeline and accompanying task to automate releasing Python packages from OCI snapshots to a Pulp-backed repository

New Features:
- Add calunga-push-to-pulp Tekton pipeline to verify resources, collect and reduce snapshot data, validate enterprise contract, and push Python packages to Pulp
- Introduce push-py-pulp Tekton task to extract Python artifacts from OCI images and upload them to a Pulp repository