### PR TITLE
Only rebuild get-config task on relevant changes

### DIFF
--- a/.tekton/task-get-config-pull-request.yaml
+++ b/.tekton/task-get-config-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && ( "tasks/get-config.yaml".pathChanged() || ".tekton/task-get-config-pull-request.yaml".pathChanged() || ".tekton/bundle-build-pipeline.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga-v2

--- a/.tekton/task-get-config-push.yaml
+++ b/.tekton/task-get-config-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && ( "tasks/get-config.yaml".pathChanged() || ".tekton/task-get-config-push.yaml".pathChanged() || ".tekton/bundle-build-pipeline.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga-v2


### PR DESCRIPTION
## Summary by Sourcery

Restrict the get-config Tekton task to only rerun on main branch pull_request and push events when relevant config or pipeline files have changed

CI:
- Add pathChanged() filters for tasks/get-config.yaml, .tekton/task-get-config-pull-request.yaml, and .tekton/bundle-build-pipeline.yaml in the pull_request trigger
- Add pathChanged() filters for tasks/get-config.yaml, .tekton/task-get-config-push.yaml, and .tekton/bundle-build-pipeline.yaml in the push trigger