### PR TITLE
Add UBI9-based builder image with Python 3.12

### DIFF
--- a/builder/examples/Containerfile.ubi9
+++ b/builder/examples/Containerfile.ubi9
@@ -1,0 +1,49 @@
+# This Containerfile is inspired by the Containerfile used by Hermeto:
+#   https://github.com/hermetoproject/hermeto/blob/main/Dockerfile
+
+FROM registry.access.redhat.com/ubi9/ubi@sha256:dec374e05cc13ebbc0975c9f521f3db6942d27f8ccdf06b180160490eef8bdbc as ubi
+
+########################
+# PREPARE OUR BASE IMAGE
+########################
+FROM ubi as base
+RUN dnf -y install \
+    --setopt install_weak_deps=0 \
+    --nodocs \
+    python3.12 \
+    python3.12-devel \
+    libffi-devel \
+    rust \
+    cargo \
+    openssl-devel \
+    && dnf clean all
+
+###############
+# BUILD/INSTALL
+###############
+FROM base as builder
+WORKDIR /src
+
+COPY requirements.txt .
+RUN python3.12 -m venv /venv && \
+    /venv/bin/pip install -r requirements.txt --no-deps --no-cache-dir --require-hashes
+
+##########################
+# ASSEMBLE THE FINAL IMAGE
+##########################
+FROM base
+LABEL maintainer="Red Hat"
+
+COPY --from=builder /venv /venv
+
+COPY scripts/* /usr/local/bin/
+
+RUN \
+    ln -s /venv/bin/fromager /usr/local/bin/fromager && \
+    ln -s /venv/bin/wheel /usr/local/bin/wheel
+
+# Force the stdout and stderr streams to be unbuffered.
+# https://docs.python.org/3/using/cmdline.html#envvar-PYTHONUNBUFFERED
+ENV PYTHONUNBUFFERED=1
+
+CMD ["fromager"]


### PR DESCRIPTION
Follow up to CALUNGA-9. This commit adds a UBI9-based builder image with Python 3.12 to satisfy the fromager requirement (Python >=3.11).

This new image was successfully used to test installing wheels built on RHEL 9 on a RHEL 10 system.

JIRA: CALUNGA-14

## Summary by Sourcery

Update builder Containerfile to use UBI 9 and upgrade Python to 3.12

Enhancements:
- Switch builder base image from UBI 10 to UBI 9 with a pinned digest
- Install python3.12 and python3.12-devel instead of python3 packages
- Use python3.12 for creating the virtual environment in the builder stage