### PR TITLE
Add task to release pipeline to generate signatures for each wheel

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -119,7 +119,7 @@ spec:
           - name: name
             value: git-clone-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:3f1b468066b301083d8550e036f5a654fcb064810bd29eb06fec6d8ad3e35b9c
+            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:3dc39eae48745a96097c07c577b944d6203a91c35d3f71d9ed5feab41d327a6a
           - name: kind
             value: task
         resolver: bundles

--- a/pipelines/release.yaml
+++ b/pipelines/release.yaml
@@ -69,6 +69,13 @@ spec:
     - name: pulpRepository
       type: string
       default: mypypi
+    - name: cosignSecretName
+      type: string
+      description: >-
+        The name of the Kubernetes secret containing the cosign signing key.
+        The secret must have a 'cosign.key' data field. If not provided or empty,
+        attestations will be generated but not signed.
+      default: "cosign-signing-key"
     - name: config
       description: Name of the ConfigMap with config options, e.g. ociStorage
       type: string
@@ -206,6 +213,8 @@ spec:
           value: $(params.pulpSecretName)
         - name: PULP_REPOSITORY
           value: $(params.pulpRepository)
+        - name: COSIGN_SECRET_NAME
+          value: $(params.cosignSecretName)
         - name: sourceDataArtifact
           value: "$(tasks.reduce-snapshot.results.sourceDataArtifact)"
       runAfter:

--- a/tasks/push-py-pulp.yaml
+++ b/tasks/push-py-pulp.yaml
@@ -36,10 +36,21 @@ spec:
       # need to specify a subfolder during the extract to avoid the error:
       # tar: .: Cannot change mode to rwxr-sr-x: Operation not permitted
       default: "/var/workdir/ta"
+    - name: COSIGN_SECRET_NAME
+      type: string
+      description: >-
+        The name of the secret containing the cosign signing key.
+        The secret must have a 'cosign.key' data field containing the private key.
+        If not provided, attestations will be generated but not signed.
+      default: ""
   volumes:
     - name: pulp-secret
       secret:
         secretName: $(params.PULP_SECRET_NAME)
+    - name: cosign-secret
+      secret:
+        secretName: $(params.COSIGN_SECRET_NAME)
+        optional: true
     - name: workdir
       emptyDir: {}
   stepTemplate:
@@ -98,8 +109,17 @@ spec:
 
         ls -la "${FILES_DIR}"
 
+    - name: generate-and-sign-attestations
+      image: quay.io/redhat-user-workloads/calunga-tenant/plumbing-utils@sha256:53984eabcf56d230dfa4298392520c9d68d2c5a353e1c54550772cc4db8c9999
+      volumeMounts:
+        - name: cosign-secret
+          mountPath: "/etc/cosign-secret"
+          readOnly: true
+      command:
+        - generate-and-sign-attestations
+
     # TODO: Use nudging to keep this up to date.
     - name: upload
-      image: quay.io/redhat-user-workloads/calunga-tenant/plumbing-utils@sha256:ce1e7cdf0c9281370c7fd6ed98944247ca744d8a6ca761968df6373639526776
+      image: quay.io/redhat-user-workloads/calunga-tenant/plumbing-utils@sha256:53984eabcf56d230dfa4298392520c9d68d2c5a353e1c54550772cc4db8c9999
       command:
         - pulp-upload

--- a/utils/scripts/generate-and-sign-attestations
+++ b/utils/scripts/generate-and-sign-attestations
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "=== Attestation Generation and Signing Step ==="
+
+# Install cosign
+echo "Installing cosign..."
+curl -sLO https://github.com/sigstore/cosign/releases/download/v2.2.4/cosign-linux-amd64
+chmod +x cosign-linux-amd64
+mv cosign-linux-amd64 /usr/local/bin/cosign
+
+echo "Cosign version:"
+cosign version
+
+# Check if signing key is available
+COSIGN_KEY_PATH="/etc/cosign-secret/cosign.key"
+if [ -f "${COSIGN_KEY_PATH}" ]; then
+  echo "Cosign signing key found - attestations will be signed"
+  SIGNING_ENABLED=true
+else
+  echo "No cosign signing key provided - attestations will not be signed"
+  echo "To enable signing, provide COSIGN_SECRET_NAME parameter"
+  SIGNING_ENABLED=false
+fi
+
+echo ""
+echo "Generating release-time attestations for wheels"
+
+# Get release timestamp
+RELEASE_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+echo "Release timestamp: ${RELEASE_TIME}"
+
+ATT_COUNT=0
+SIGNED_COUNT=0
+
+cd "${FILES_DIR}"
+
+echo ""
+echo "Files in directory:"
+ls -lah
+
+echo ""
+echo "Processing wheel files..."
+
+# Process only .whl and .tar.gz files
+shopt -s nullglob
+for WHEEL in *.whl *.tar.gz; do
+  # Skip if no files match
+  if [ ! -f "${WHEEL}" ]; then
+    echo "Skipping non-existent file: ${WHEEL}"
+    continue
+  fi
+
+  echo ""
+  echo "Processing: ${WHEEL}"
+
+  # Calculate wheel hash
+  WHEEL_SHA256=$(sha256sum "${WHEEL}" | cut -d' ' -f1)
+  echo "  SHA256: ${WHEEL_SHA256}"
+
+  # Create SLSA provenance predicate using heredoc
+  PREDICATE_FILE="/tmp/${WHEEL}.predicate.json"
+  cat > "${PREDICATE_FILE}" <<EOF
+{
+  "_type": "https://in-toto.io/Statement/v0.1",
+  "predicateType": "https://slsa.dev/provenance/v0.2",
+  "subject": [
+    {
+      "name": "${WHEEL}",
+      "digest": {
+        "sha256": "${WHEEL_SHA256}"
+      }
+    }
+  ],
+  "predicate": {
+    "builder": {
+      "id": "https://konflux-ci.dev/calunga"
+    },
+    "buildType": "https://konflux-ci.dev/PythonWheelBuild@v1",
+    "metadata": {
+      "buildFinishedOn": "${RELEASE_TIME}",
+      "completeness": {
+        "parameters": true,
+        "environment": true,
+        "materials": true
+      },
+      "reproducible": true
+    }
+  }
+}
+EOF
+
+  ATT_FILE="${WHEEL}.att"
+
+  if [ "${SIGNING_ENABLED}" = true ]; then
+    # Sign the attestation with cosign using the provided key
+    echo "Signing attestation with cosign"
+    if COSIGN_PASSWORD="" cosign attest-blob "${WHEEL}" \
+      --predicate="${PREDICATE_FILE}" \
+      --type=https://slsa.dev/provenance/v0.2 \
+      --key="${COSIGN_KEY_PATH}" \
+      --yes \
+      --output-file="${ATT_FILE}" 2>&1; then
+      echo "Signed attestation: ${ATT_FILE}"
+      SIGNED_COUNT=$((SIGNED_COUNT + 1))
+    else
+      echo "Failed to sign, creating unsigned attestation"
+      cp "${PREDICATE_FILE}" "${ATT_FILE}"
+    fi
+  else
+    # Create unsigned attestation
+    cp "${PREDICATE_FILE}" "${ATT_FILE}"
+    echo "Created unsigned attestation: ${ATT_FILE}"
+  fi
+
+  ATT_COUNT=$((ATT_COUNT + 1))
+  rm -f "${PREDICATE_FILE}"
+done
+
+echo ""
+echo "=========================================="
+echo "Attestation Generation Summary:"
+echo "  Total attestations: ${ATT_COUNT}"
+if [ "${SIGNING_ENABLED}" = true ]; then
+  echo "  Signed: ${SIGNED_COUNT}"
+else
+  echo "  Signed: 0 (no signing key provided)"
+fi
+echo "=========================================="
+
+echo ""
+echo "Final files in directory (wheels, signatures, and attestations):"
+ls -lah
+

--- a/utils/scripts/pulp-upload
+++ b/utils/scripts/pulp-upload
@@ -5,7 +5,8 @@ ls -la .
 
 pulp --help
 
-for pkg in *; do
+# Only upload .whl and .tar.gz files. Skipping .att files for now.
+for pkg in *.whl *.tar.gz; do
     if [ -f "$pkg" ]; then
     echo "Uploading $pkg..."
     pulp --base-url "${PULP_BASE_URL}" --api-root "${PULP_API_ROOT}" --domain "${PULP_DOMAIN}" \


### PR DESCRIPTION
This PR adds automated generation and signing of attestations for Python wheels during the release process. This change enhances supply chain security and provides provenance tracking.

## Summary by Sourcery

New Features:
- Add generate-and-sign-attestations task that generates SLAs provenance predicate files with release timestamp and SHA-256 digest and signs them with cosign