### PR TITLE
fix: Add missing dist package normalization to integration test task

### DIFF
--- a/tasks/install-and-import-wheels.yaml
+++ b/tasks/install-and-import-wheels.yaml
@@ -73,7 +73,7 @@ spec:
         package_map = importlib.metadata.packages_distributions()
         import_names = [
             imp_pkg for imp_pkg, dists in package_map.items()
-            if dist_name in [d.lower() for d in dists]
+            if dist_name in [d.replace('_', '-').lower() for d in dists]
         ]
         if not import_names:
             print(f'ERROR: No import names found for distribution: {dist_name}')


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix integration test package resolution by treating underscores and hyphens equivalently in distribution names.