### PR TITLE
Remove pip package installation from integration test script

### DIFF
--- a/tasks/install-and-import-wheels.yaml
+++ b/tasks/install-and-import-wheels.yaml
@@ -59,7 +59,7 @@ spec:
         #!/bin/bash
         set -euo pipefail
 
-        dnf install -y python3.12 python3.12-pip
+        dnf install -y python3.12
 
         # Setup the Python script to verify import
         cat <<EOF > /tmp/verify_import.py


### PR DESCRIPTION
The installation fails on Fedora and is unnecessary in the test script on both Fedora and UBI images.

JIRA: CALUNGA-53

## Summary by Sourcery

Build:
- Update integration test task to stop installing python3.12-pip explicitly in the container image.