### PR TITLE
updated any konflux references to the latest

### DIFF
--- a/pipelines/release.yaml
+++ b/pipelines/release.yaml
@@ -88,7 +88,7 @@ spec:
         - name: name
           value: get-config
         - name: bundle
-          value: quay.io/redhat-user-workloads/calunga-tenant/task-get-config@sha256:a3e080e2172306f5c53082aa171d936fec3d7f23b45fcbf410160aa1819c538a
+          value: quay.io/redhat-user-workloads/calunga-tenant/task-get-config@sha256:5c4e235239f2b791238a47fde049dabb71c33724c35419e939e0792b70728d80
         - name: kind
           value: task
         resolver: bundles
@@ -197,7 +197,7 @@ spec:
         - name: name
           value: push-py-pulp
         - name: bundle
-          value: quay.io/redhat-user-workloads/calunga-tenant/task-push-py-pulp@sha256:eda2f3069fb3267a4487772c9f59cf68f2ccbf287fbdb6d8412a1b64fbcf10be
+          value: quay.io/redhat-user-workloads/calunga-tenant/task-push-py-pulp@sha256:eb208481156cdeed0b9243c2fd4d9fe84726b322de81075204c95092d1505f71
         - name: kind
           value: task
       params:

--- a/tasks/push-py-pulp.yaml
+++ b/tasks/push-py-pulp.yaml
@@ -110,7 +110,7 @@ spec:
         ls -la "${FILES_DIR}"
 
     - name: generate-and-sign-attestations
-      image: quay.io/redhat-user-workloads/calunga-tenant/plumbing-utils@sha256:305df34752eebeb277f53f8dad7e5893eb70a5d85bae8ddf35c26b689776aec1
+      image: quay.io/redhat-user-workloads/calunga-tenant/plumbing-utils@sha256:6aaeaf2e62d657cf9ace5aadd4987cfe06b0a66b665f8035a5f71c4985426891
       volumeMounts:
         - name: cosign-secret
           mountPath: "/etc/cosign-secret"
@@ -120,6 +120,6 @@ spec:
 
     # TODO: Use nudging to keep this up to date.
     - name: upload
-      image: quay.io/redhat-user-workloads/calunga-tenant/plumbing-utils@sha256:305df34752eebeb277f53f8dad7e5893eb70a5d85bae8ddf35c26b689776aec1
+      image: quay.io/redhat-user-workloads/calunga-tenant/plumbing-utils@sha256:6aaeaf2e62d657cf9ace5aadd4987cfe06b0a66b665f8035a5f71c4985426891
       command:
         - pulp-upload


### PR DESCRIPTION
## Summary by Sourcery

Update pipeline and task configurations to use newer Konflux-related bundles and plumbing-utils images.

Enhancements:
- Refresh Tekton release pipeline task bundles to the latest published digests.
- Update push-py-pulp task to use the latest plumbing-utils image for attestation generation and artifact upload.