### PR TITLE
Add --non-interactive into pulp-upload

### DIFF
--- a/utils/scripts/pulp-upload
+++ b/utils/scripts/pulp-upload
@@ -15,10 +15,10 @@ attestation_files=(*.attestation)
 
 if [ ${#attestation_files[@]} -gt 0 ]; then
     echo "Uploading packages with attestations..."
-    twine upload --repository-url "${REPOSITORY_URL}" --client-cert "${CLIENT_CERT_FILE}" --attestations *.whl *.tar.gz *.attestation
+    twine upload --non-interactive --repository-url "${REPOSITORY_URL}" --client-cert "${CLIENT_CERT_FILE}" --attestations *.whl *.tar.gz *.attestation
 else
     echo "Uploading packages..."
-    twine upload --repository-url "${REPOSITORY_URL}" --client-cert "${CLIENT_CERT_FILE}" *.whl *.tar.gz
+    twine upload --non-interactive --repository-url "${REPOSITORY_URL}" --client-cert "${CLIENT_CERT_FILE}" *.whl *.tar.gz
 fi
 
 rm -f "${CLIENT_CERT_FILE}"


### PR DESCRIPTION
When using mTLS auth with Pulp we need to tell twine not to ask for credentials. This fix adds the `--non-interactive` flag to the twine command

## Summary by Sourcery

Enhancements:
- Update the pulp-upload script to invoke twine with the --non-interactive flag when uploading to Pulp, avoiding credential prompts in automated or mTLS setups.