### PR TITLE
Update REPOSITORY_URL var in pulp-upload to /legacy/

### DIFF
--- a/utils/scripts/pulp-upload
+++ b/utils/scripts/pulp-upload
@@ -4,7 +4,7 @@ set -euo pipefail
 cd "${FILES_DIR}"
 ls -la .
 
-REPOSITORY_URL="${PULP_BASE_URL}${PULP_API_ROOT}pypi/${PULP_DOMAIN}/${PULP_REPOSITORY}/"
+REPOSITORY_URL="${PULP_BASE_URL}${PULP_API_ROOT}pypi/${PULP_DOMAIN}/${PULP_REPOSITORY}/legacy/"
 CLIENT_CERT_FILE="/tmp/client-cert.pem"
 # twine requires both cert/key in a single file
 cat /etc/pulp-secret/key /etc/pulp-secret/cert > "${CLIENT_CERT_FILE}"


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Adjust pulp-upload script to use the updated repository URL path for uploads.