### PR TITLE
Remove `pulp/` from PULP_API_ROOT in push-py-pulp task

### DIFF
--- a/tasks/push-py-pulp.yaml
+++ b/tasks/push-py-pulp.yaml
@@ -21,7 +21,7 @@ spec:
     - name: PULP_API_ROOT
       type: string
       description: The API root path of the Pulp server
-      default: "/api/pulp/"
+      default: "/api/"
     - name: PULP_DOMAIN
       type: string
       description: The domain to use for Pulp operations

--- a/utils/scripts/pulp-upload
+++ b/utils/scripts/pulp-upload
@@ -4,7 +4,7 @@ set -euo pipefail
 cd "${FILES_DIR}"
 ls -la .
 
-REPOSITORY_URL="${PULP_BASE_URL}${PULP_API_ROOT}pypi/${PULP_DOMAIN}/${PULP_REPOSITORY}/legacy/"
+REPOSITORY_URL="${PULP_BASE_URL}${PULP_API_ROOT}pypi/${PULP_DOMAIN}/${PULP_REPOSITORY}/simple/"
 CLIENT_CERT_FILE="/tmp/client-cert.pem"
 # twine requires both cert/key in a single file
 cat /etc/pulp-secret/key /etc/pulp-secret/cert > "${CLIENT_CERT_FILE}"


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Adjust the default PULP_API_ROOT parameter in the push-py-pulp Tekton task from /api/pulp/ to /api/.