### PR TITLE
Update the pulpApiRoot in the release.yaml

### DIFF
--- a/pipelines/release.yaml
+++ b/pipelines/release.yaml
@@ -62,7 +62,7 @@ spec:
       default: public-calunga
     - name: pulpApiRoot
       type: string
-      default: "/api/pulp/"
+      default: "/api/"
     - name: pulpSecretName
       type: string
       default: pulp-credentials


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update release pipeline parameter to point pulpApiRoot default from /api/pulp/ to /api/.