### PR TITLE
migrating to calunga-prod

### DIFF
--- a/pipelines/release.yaml
+++ b/pipelines/release.yaml
@@ -59,7 +59,7 @@ spec:
       default: https://mtls.internal.console.redhat.com
     - name: pulpDomain
       type: string
-      default: public-calunga
+      default: calunga-prod
     - name: pulpApiRoot
       type: string
       default: "/api/"
@@ -68,7 +68,7 @@ spec:
       default: pulp-credentials
     - name: pulpRepository
       type: string
-      default: mypypi
+      default: main
     - name: cosignSecretName
       type: string
       description: >-

--- a/utils/scripts/pulp-upload
+++ b/utils/scripts/pulp-upload
@@ -30,4 +30,4 @@ rm -f "${CLIENT_CERT_FILE}"
 
 echo ""
 echo "Upload complete!"
-echo "Index URL: https://console.redhat.com/api/pulp-content/public-calunga/mypypi/simple/"
+echo "Index URL: https://console.redhat.com/api/pulp-content/calunga-prod/main/simple/"


### PR DESCRIPTION
## Summary by Sourcery

Update release pipeline configuration to target the calunga-prod Pulp environment instead of the previous public-calunga setup.

Enhancements:
- Change default Pulp domain in the release pipeline from public-calunga to calunga-prod.
- Update the default Pulp repository name in the release pipeline from mypypi to main.