### PR TITLE
Increase timeout for the GH action test job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,12 @@ jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    
+    timeout-minutes: 60
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
-      
+
     - name: Check for changes in builder/
       uses: dorny/paths-filter@v4
       id: filter


### PR DESCRIPTION
Building stuff from source takes some time, current timeout of 30 minutes was too low. Building the image alone takes ~35 minutes. Timeout increased to 60 minutes.

## Summary by Sourcery

CI:
- Extend the GitHub Actions test job timeout from 30 to 60 minutes to prevent premature failures during lengthy image builds.