### PR TITLE
Remove auditwheel SBOM from built wheels & Add file_name to PURL

### DIFF
--- a/builder/Containerfile
+++ b/builder/Containerfile
@@ -309,6 +309,8 @@ RUN dnf -y install \
     --setopt install_weak_deps=0 \
     perl-IPC-Cmd \
     cmake \
+    zip \
+    unzip \
     && dnf clean all \
     && rm -rf /var/cache/dnf
 COPY requirements.txt .
@@ -319,6 +321,7 @@ COPY scripts/* /usr/local/bin/
 COPY overrides/settings.yaml /usr/local/share/fromager/overrides/settings.yaml
 
 RUN \
+    ln -s /src/venv/bin/python /usr/local/bin/python3 && \
     ln -s /src/venv/bin/fromager /usr/local/bin/fromager && \
     ln -s /src/venv/bin/wheel /usr/local/bin/wheel
 

--- a/builder/overrides/settings.yaml
+++ b/builder/overrides/settings.yaml
@@ -4,3 +4,4 @@ sbom:
   namespace: "https://www.redhat.com"
   creators:
     - "Organization: Red Hat"
+  repository_url: "https://packages.redhat.com"

--- a/builder/requirements.in
+++ b/builder/requirements.in
@@ -1,1 +1,1 @@
-fromager>=0.80.0
+fromager>=0.81.0

--- a/builder/requirements.txt
+++ b/builder/requirements.txt
@@ -169,9 +169,9 @@ elfdeps==0.2.0 \
     --hash=sha256:8df0b4f0deceae9faf37bf5f1ad1b46fa5bc7c1731d016df0bdec2513ec82750 \
     --hash=sha256:d99002612d9e08548e14dda6396c7146071cf4150d674eb98f4ced0ea052968b
     # via fromager
-fromager==0.80.0 \
-    --hash=sha256:32a9391698a30bb155fbb518b93ede165982e4e1fe7681e1924ea464a1b1ff86 \
-    --hash=sha256:ba7eecce294b051e8adf05a29cbd6fe224ce208545f1232e4945ff9babb10db0
+fromager==0.81.0 \
+    --hash=sha256:47b6946c238beb7a6b60dcf689bc3088f6511cf4d8fbb9e214e002ccd39aab24 \
+    --hash=sha256:dc9524c36fd61db10a610c99eda46283432210fc8a9e2378230b20d225230e12
     # via -r builder/requirements.in
 h11==0.16.0 \
     --hash=sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1 \
@@ -199,6 +199,10 @@ mdurl==0.1.2 \
     --hash=sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8 \
     --hash=sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba
     # via markdown-it-py
+packageurl-python==0.17.6 \
+    --hash=sha256:1252ce3a102372ca6f86eb968e16f9014c4ba511c5c37d95a7f023e2ca6e5c25 \
+    --hash=sha256:31a85c2717bc41dd818f3c62908685ff9eebcb68588213745b14a6ee9e7df7c9
+    # via fromager
 packaging==26.0 \
     --hash=sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4 \
     --hash=sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529

--- a/builder/scripts/build-wheels
+++ b/builder/scripts/build-wheels
@@ -158,9 +158,37 @@ for PACKAGE in "${PACKAGES[@]}"; do
     if [ -n "$(find wheels-repo/downloads -name '*linux_x86_64.whl' | head -1)" ]; then
         log manylinux wheels have been found, auditwheel step required
         auditwheel repair wheels-repo/downloads/*linux_x86_64.whl -w wheels-repo/downloads
+
+        # auditwheel >= 6.5 embeds CycloneDX SBOMs in repaired wheels by default.
+        # Remove only auditwheel's SBOMs (*.cdx.json) and leave Fromager's intact.
+        log "Removing auditwheel-generated SBOMs from repaired manylinux wheels"
+        for whl in wheels-repo/downloads/*manylinux*.whl; do
+            [ -f "$whl" ] || continue
+            zip -d "$whl" '*.dist-info/sboms/*.cdx.json' 2>/dev/null || true
+            # Update RECORD so the wheel stays valid
+            record_path=$(unzip -Z1 "$whl" | grep '\.dist-info/RECORD$' || true)
+            if [ -n "$record_path" ]; then
+                tmpdir=$(mktemp -d)
+                unzip -o "$whl" "$record_path" -d "$tmpdir"
+                sed -i '/\.cdx\.json/d' "$tmpdir/$record_path"
+                (cd "$tmpdir" && zip "$OLDPWD/$whl" "$record_path")
+                rm -rf "$tmpdir"
+            fi
+        done
     else
         log No manylinux wheels found, skipping auditwheel step
     fi
+
+    # Patch Fromager SBOMs with PURL identifying the wheel and its origin index.
+    # Must run after auditwheel repair since the final filename isn't known until then.
+    log "Patching Fromager SBOMs with PURL"
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    # Only patch pure-python and manylinux wheels (skip original linux_x86_64
+    # wheels since auditwheel already produced their manylinux replacements).
+    for whl in wheels-repo/downloads/*none-any.whl wheels-repo/downloads/*manylinux*.whl; do
+        [ -f "$whl" ] || continue
+        "$SCRIPT_DIR/patch-sbom-purl" "$whl"
+    done
 
     # Clear work-dir after processing package (but preserve sdists-repo and wheels-repo)
     log "Clearing work-dir after processing $PACKAGE (preserving sdists-repo and wheels-repo)"

--- a/builder/scripts/patch-sbom-purl
+++ b/builder/scripts/patch-sbom-purl
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Patch Fromager SPDX SBOMs inside wheels with a PURL identifier"""
+import argparse
+import base64
+import hashlib
+import json
+import sys
+import zipfile
+from pathlib import Path
+from urllib.parse import quote
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Add file_name qualifier to PURLs in Fromager SBOMs inside a wheel"
+    )
+    parser.add_argument("wheel", type=Path, help="Path to the wheel file to patch")
+    return parser.parse_args()
+
+
+def add_filename_to_purl(sbom_data, filename):
+    """Append file_name=<filename> to every PURL ref in the SBOM JSON."""
+    sbom = json.loads(sbom_data)
+    encoded_name = quote(filename, safe="")
+    for pkg in sbom.get("packages", []):
+        for ref in pkg.get("externalRefs", []):
+            if ref.get("referenceType") == "purl":
+                purl = ref["referenceLocator"]
+                if "file_name=" not in purl:
+                    separator = "&" if "?" in purl else "?"
+                    ref["referenceLocator"] = f"{purl}{separator}file_name={encoded_name}"
+    return json.dumps(sbom, indent=2).encode()
+
+
+def update_record(record_data, patched_files):
+    """Recalculate hashes in the RECORD file for any patched SBOM entries."""
+    lines = record_data.decode().splitlines()
+    new_lines = []
+    for line in lines:
+        for patched_name, patched_data in patched_files.items():
+            if line.startswith(patched_name + ","):
+                digest = base64.urlsafe_b64encode(
+                    hashlib.sha256(patched_data).digest()
+                ).rstrip(b"=").decode()
+                line = f"{patched_name},sha256={digest},{len(patched_data)}"
+                break
+        new_lines.append(line)
+    return ("\n".join(new_lines) + "\n").encode()
+
+
+def main():
+    args = parse_args()
+    whl_path = args.wheel
+
+    # First pass to discover SBOM and RECORD entries
+    with zipfile.ZipFile(whl_path) as zf:
+        all_names = zf.namelist()
+        sbom_entries = {
+            n for n in all_names
+            if ".dist-info/sboms/" in n and n.endswith(".json") and not n.endswith("/")
+        }
+        record_entry = next(
+            (n for n in all_names if n.endswith(".dist-info/RECORD")), None
+        )
+
+    if not sbom_entries:
+        print(f"  No Fromager SBOM found in {whl_path.name}")
+        return
+
+    patched_files = {}
+    tmp = whl_path.with_suffix(".tmp")
+    record_info = None
+
+    # RECORD must be written after patching since it contains hashes of the modified SBOMs
+    with (
+        zipfile.ZipFile(whl_path) as zf_in,
+        zipfile.ZipFile(tmp, "w", compression=zipfile.ZIP_DEFLATED) as zf_out,
+    ):
+        for item in zf_in.infolist():
+            if item.filename == record_entry:
+                record_info = item
+                continue
+            data = zf_in.read(item.filename)
+            if item.filename in sbom_entries:
+                data = add_filename_to_purl(data, whl_path.name)
+                patched_files[item.filename] = data
+            zf_out.writestr(item, data)
+
+        if record_info:
+            record_data = zf_in.read(record_info.filename)
+            if patched_files:
+                record_data = update_record(record_data, patched_files)
+            zf_out.writestr(record_info, record_data)
+
+    tmp.replace(whl_path)
+    print(f"  Patched {whl_path.name} SBOM: added file_name to PURL")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        print(f"  ERROR patching: {e}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
auditwheel >= 6.5 embeds CycloneDX SBOMs in repaired wheels by default. We remove them since we are using Fromager-generated SBOMs instead.

## Summary by Sourcery

Build:
- Update wheel build script to strip auditwheel-generated CycloneDX SBOMs from produced wheels.