### PR TITLE
Wire source-built zlib, bzip2, libpng & libtiff into Containerfile

### DIFF
--- a/builder/Containerfile
+++ b/builder/Containerfile
@@ -205,6 +205,44 @@ RUN export OPENBLAS_VERSION=0.3.31 && \
     /opt/_internal/build_scripts/build-openblas.sh
 
 
+FROM build_base AS build_zlib
+COPY build_scripts/build-zlib.sh /opt/_internal/build_scripts/
+RUN export ZLIB_VERSION=1.3.1 && \
+    export ZLIB_HASH=9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23 && \
+    export ZLIB_DOWNLOAD_URL=https://github.com/madler/zlib/releases/download/v1.3.1 && \
+    /opt/_internal/build_scripts/build-zlib.sh
+
+
+FROM build_base AS build_bzip2
+COPY build_scripts/build-bzip2.sh /opt/_internal/build_scripts/
+RUN --mount=type=bind,from=static_clang,target=/tmp/cross-compiler,ro \
+    export BZIP2_VERSION=1.0.8 && \
+    export BZIP2_HASH=ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269 && \
+    export BZIP2_DOWNLOAD_URL=https://sourceware.org/pub/bzip2 && \
+    /tmp/cross-compiler/entrypoint /opt/_internal/build_scripts/build-bzip2.sh
+
+
+FROM build_base AS build_libpng
+COPY --from=build_zlib /manylinux-buildfs /
+COPY build_scripts/build-libpng.sh /opt/_internal/build_scripts/
+RUN --mount=type=bind,from=static_clang,target=/tmp/cross-compiler,ro \
+    export LIBPNG_VERSION=1.6.44 && \
+    export LIBPNG_HASH=60c4da1d5b7f0aa8d158da48e8f8afa9773c1c8baa5d21974df61f1886b8ce8e && \
+    export LIBPNG_DOWNLOAD_URL=https://download.sourceforge.net/libpng && \
+    /tmp/cross-compiler/entrypoint /opt/_internal/build_scripts/build-libpng.sh
+
+
+FROM build_base AS build_libtiff
+COPY --from=build_zlib /manylinux-buildfs /
+COPY --from=build_libjpeg_turbo /manylinux-buildfs /
+COPY build_scripts/build-libtiff.sh /opt/_internal/build_scripts/
+RUN --mount=type=bind,from=static_clang,target=/tmp/cross-compiler,ro \
+    export LIBTIFF_VERSION=4.6.0 && \
+    export LIBTIFF_HASH=e178649607d1e22b51cf361dd20a3753f244f022eefab1f2f218fc62ebaf87d2 && \
+    export LIBTIFF_DOWNLOAD_URL=https://download.osgeo.org/libtiff && \
+    /tmp/cross-compiler/entrypoint /opt/_internal/build_scripts/build-libtiff.sh
+
+
 FROM --platform=${BUILDPLATFORM} ghcr.io/sigstore/cosign/cosign:v${MANYLINUX_COSIGN_VERSION} AS cosign-bin
 
 
@@ -225,6 +263,10 @@ COPY build_scripts/build-cpython.sh /opt/_internal/build_scripts/
 
 
 FROM build_cpython AS build_cpython312
+COPY --from=build_zlib /manylinux-buildfs /
+COPY --from=build_bzip2 /manylinux-buildfs /
+COPY --from=build_libpng /manylinux-buildfs /
+COPY --from=build_libtiff /manylinux-buildfs /
 COPY --from=build_libjpeg_turbo /manylinux-buildfs /
 COPY --from=build_libyaml /manylinux-buildfs /
 COPY --from=build_libxml2 /manylinux-buildfs /
@@ -237,6 +279,10 @@ RUN --mount=type=bind,from=static_clang,target=/tmp/cross-compiler,ro \
 
 
 FROM scratch AS merged_buildfs
+COPY --from=build_zlib /manylinux-buildfs /
+COPY --from=build_bzip2 /manylinux-buildfs /
+COPY --from=build_libpng /manylinux-buildfs /
+COPY --from=build_libtiff /manylinux-buildfs /
 COPY --from=build_libjpeg_turbo /manylinux-buildfs /
 COPY --from=build_libyaml /manylinux-buildfs /
 COPY --from=build_libxml2 /manylinux-buildfs /
@@ -252,6 +298,10 @@ COPY --from=build_zstd /manylinux-rootfs /
 COPY --from=build_sqlite3 /manylinux-rootfs /
 COPY --from=build_git /manylinux-rootfs /
 COPY --from=build_rust /manylinux-rootfs /
+COPY --from=build_zlib /manylinux-rootfs /
+COPY --from=build_bzip2 /manylinux-rootfs /
+COPY --from=build_libpng /manylinux-rootfs /
+COPY --from=build_libtiff /manylinux-rootfs /
 COPY --from=build_libjpeg_turbo /manylinux-rootfs /
 COPY --from=build_libyaml /manylinux-rootfs /
 COPY --from=build_libxml2 /manylinux-rootfs /
@@ -266,13 +316,15 @@ COPY --from=merged_buildfs /opt /opt
 COPY --from=merged_buildfs /usr/local/lib/pkgconfig /usr/local/lib/pkgconfig
 # Create symlinks in standard paths so build systems that don't use pkg-config
 # (e.g. PyYAML's setup.py) can find our source-built headers and libraries
-RUN for dir in /opt/_internal/lib*/include /opt/_internal/openblas*/include; do \
-        [ -d "$dir" ] && for item in "$dir"/*; do \
+RUN for dir in /opt/_internal/lib*/include /opt/_internal/openblas*/include /opt/_internal/zlib*/include /opt/_internal/bzip2*/include; do \
+        [ -d "$dir" ] || continue; \
+        for item in "$dir"/*; do \
             ln -sf "$item" /usr/local/include/; \
         done; \
     done && \
-    for dir in /opt/_internal/lib*/lib /opt/_internal/openblas*/lib; do \
-        [ -d "$dir" ] && for lib in "$dir"/lib*.so; do \
+    for dir in /opt/_internal/lib*/lib /opt/_internal/openblas*/lib /opt/_internal/zlib*/lib /opt/_internal/bzip2*/lib; do \
+        [ -d "$dir" ] || continue; \
+        for lib in "$dir"/lib*.so; do \
             [ -f "$lib" ] && ln -sf "$lib" /usr/local/lib/; \
         done; \
     done

--- a/builder/build_scripts/build-bzip2.sh
+++ b/builder/build_scripts/build-bzip2.sh
@@ -36,12 +36,15 @@ mkdir -p /manylinux-rootfs"${PREFIX}"/include
 mkdir -p /manylinux-rootfs"${PREFIX}"/bin
 
 cp -a libbz2.so* /manylinux-rootfs"${PREFIX}"/lib/
+ln -sf libbz2.so.${BZIP2_VERSION} /manylinux-rootfs"${PREFIX}"/lib/libbz2.so
 cp bzlib.h /manylinux-rootfs"${PREFIX}"/include/
 
 # Build and install utilities
 make clean > /dev/null
 make CC="${CC:-gcc}" CFLAGS="${MANYLINUX_CFLAGS}" > /dev/null
-cp bzip2 bunzip2 bzcat /manylinux-rootfs"${PREFIX}"/bin/
+cp bzip2 /manylinux-rootfs"${PREFIX}"/bin/
+ln -f /manylinux-rootfs"${PREFIX}"/bin/bzip2 /manylinux-rootfs"${PREFIX}"/bin/bunzip2
+ln -f /manylinux-rootfs"${PREFIX}"/bin/bzip2 /manylinux-rootfs"${PREFIX}"/bin/bzcat
 
 popd
 rm -rf "${BZIP2_ROOT}" "${BZIP2_ROOT}.tar.gz"

--- a/builder/build_scripts/build-libtiff.sh
+++ b/builder/build_scripts/build-libtiff.sh
@@ -25,8 +25,8 @@ tar xf "${LIBTIFF_ROOT}.tar.xz"
 pushd "${LIBTIFF_ROOT}"
 
 # Build with CMake
-mkdir build
-cd build
+mkdir -p _build
+cd _build
 cmake .. \
     -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
     -DCMAKE_BUILD_TYPE=Release \
@@ -60,9 +60,9 @@ cp -rlf /manylinux-rootfs/* /manylinux-buildfs/
 
 # Create symlinks for pkgconfig
 mkdir -p /manylinux-buildfs/usr/local/lib/pkgconfig/
-for pc in "${PREFIX}"/lib/pkgconfig/*.pc; do
-    if [ -f "/manylinux-buildfs${pc}" ]; then
-        ln -s "${pc}" /manylinux-buildfs/usr/local/lib/pkgconfig/$(basename "$pc")
+for pc in /manylinux-buildfs"${PREFIX}"/lib/pkgconfig/*.pc; do
+    if [ -f "$pc" ]; then
+        ln -s "${PREFIX}/lib/pkgconfig/$(basename "$pc")" /manylinux-buildfs/usr/local/lib/pkgconfig/$(basename "$pc")
     fi
 done
 

--- a/builder/build_scripts/build-zlib.sh
+++ b/builder/build_scripts/build-zlib.sh
@@ -25,7 +25,7 @@ tar xfz "${ZLIB_ROOT}.tar.gz"
 pushd "${ZLIB_ROOT}"
 
 # Configure and build
-CFLAGS="${MANYLINUX_CFLAGS}" \
+CFLAGS="${MANYLINUX_CFLAGS} -fPIC" \
 LDFLAGS="${MANYLINUX_LDFLAGS}" \
 ./configure --prefix="${PREFIX}" > /dev/null
 
@@ -48,7 +48,7 @@ cp -rlf /manylinux-rootfs/* /manylinux-buildfs/
 
 # Create symlink for pkgconfig
 mkdir -p /manylinux-buildfs/usr/local/lib/pkgconfig/
-if [ -f "${PREFIX}/lib/pkgconfig/zlib.pc" ]; then
+if [ -f /manylinux-buildfs"${PREFIX}"/lib/pkgconfig/zlib.pc ]; then
     ln -s "${PREFIX}/lib/pkgconfig/zlib.pc" /manylinux-buildfs/usr/local/lib/pkgconfig/zlib.pc
 fi
 


### PR DESCRIPTION
Complete Phase 4 of the UBI8 migration by adding build stages for zlib 1.3.1, bzip2 1.0.8, libpng 1.6.44, and libtiff 4.6.0. The build scripts already existed but were never integrated.

Also fix bugs in build-zlib.sh (missing -fPIC, wrong pkgconfig symlink path), build-bzip2.sh (bunzip2/bzcat hardlinks, missing unversioned .so symlink), and build-libtiff.sh (build dir collision, wrong pkgconfig glob path).

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Integrate source-built zlib, bzip2, libpng, and libtiff into the UBI8-based build Containerfile and propagate their outputs into the merged build filesystem and final image artifacts.

New Features:
- Add dedicated container build stages for zlib 1.3.1, bzip2 1.0.8, libpng 1.6.44, and libtiff 4.6.0 and wire their artifacts into the manylinux build and root filesystems.

Bug Fixes:
- Fix zlib build to use position-independent code and correct the pkg-config symlink source path.
- Fix bzip2 build to provide an unversioned libbz2.so symlink and create bunzip2/bzcat as hardlink-style aliases of bzip2.
- Fix libtiff build to use an isolated build directory and correct the pkg-config file globbing path when creating symlinks.

Enhancements:
- Expose headers and shared libraries from the source-built zlib and bzip2 installations via /usr/local include and lib symlinks, extending the existing non-pkg-config discovery mechanism.