### PR TITLE
Rename Fromager SBOM to redhat.spdx.json inside built wheels

### DIFF
--- a/builder/scripts/build-wheels
+++ b/builder/scripts/build-wheels
@@ -181,7 +181,7 @@ for PACKAGE in "${PACKAGES[@]}"; do
 
     # Patch Fromager SBOMs with PURL identifying the wheel and its origin index.
     # Must run after auditwheel repair since the final filename isn't known until then.
-    log "Patching Fromager SBOMs with PURL"
+    log "Patching Fromager SBOMs: adding PURL and renaming to redhat.spdx.json"
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     # Only patch pure-python and manylinux wheels (skip original linux_x86_64
     # wheels since auditwheel already produced their manylinux replacements).

--- a/builder/scripts/patch-sbom-purl
+++ b/builder/scripts/patch-sbom-purl
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Patch Fromager SPDX SBOMs inside wheels with a PURL identifier"""
+"""Patch Fromager SPDX SBOMs inside wheels: add PURL identifier and rename to redhat.spdx.json"""
 import argparse
 import base64
 import hashlib
@@ -32,20 +32,29 @@ def add_filename_to_purl(sbom_data, filename):
     return json.dumps(sbom, indent=2).encode()
 
 
-def update_record(record_data, patched_files):
-    """Recalculate hashes in the RECORD file for any patched SBOM entries."""
+def update_record(record_data, patched_files, renamed_files):
+    """Recalculate hashes in the RECORD file for any patched/renamed SBOM entries."""
     lines = record_data.decode().splitlines()
     new_lines = []
     for line in lines:
-        for patched_name, patched_data in patched_files.items():
-            if line.startswith(patched_name + ","):
+        for old_name, new_name in renamed_files.items():
+            if line.startswith(old_name + ","):
+                patched_data = patched_files[new_name]
                 digest = base64.urlsafe_b64encode(
                     hashlib.sha256(patched_data).digest()
                 ).rstrip(b"=").decode()
-                line = f"{patched_name},sha256={digest},{len(patched_data)}"
+                line = f"{new_name},sha256={digest},{len(patched_data)}"
                 break
         new_lines.append(line)
     return ("\n".join(new_lines) + "\n").encode()
+
+
+def rename_sbom(old_name, target_basename="redhat.spdx.json"):
+    """Rename the SBOM file inside the wheel (e.g. fromager.spdx.json -> redhat.spdx.json)."""
+    parts = old_name.rsplit("/", 1)
+    if len(parts) == 2:
+        return f"{parts[0]}/{target_basename}"
+    return target_basename
 
 
 def main():
@@ -57,7 +66,7 @@ def main():
         all_names = zf.namelist()
         sbom_entries = {
             n for n in all_names
-            if ".dist-info/sboms/" in n and n.endswith(".json") and not n.endswith("/")
+            if n.endswith(".dist-info/sboms/fromager.spdx.json")
         }
         record_entry = next(
             (n for n in all_names if n.endswith(".dist-info/RECORD")), None
@@ -68,6 +77,7 @@ def main():
         return
 
     patched_files = {}
+    renamed_files = {}
     tmp = whl_path.with_suffix(".tmp")
     record_info = None
 
@@ -83,17 +93,20 @@ def main():
             data = zf_in.read(item.filename)
             if item.filename in sbom_entries:
                 data = add_filename_to_purl(data, whl_path.name)
-                patched_files[item.filename] = data
+                new_name = rename_sbom(item.filename)
+                renamed_files[item.filename] = new_name
+                patched_files[new_name] = data
+                item.filename = new_name
             zf_out.writestr(item, data)
 
         if record_info:
             record_data = zf_in.read(record_info.filename)
-            if patched_files:
-                record_data = update_record(record_data, patched_files)
+            if patched_files or renamed_files:
+                record_data = update_record(record_data, patched_files, renamed_files)
             zf_out.writestr(record_info, record_data)
 
     tmp.replace(whl_path)
-    print(f"  Patched {whl_path.name} SBOM: added file_name to PURL")
+    print(f"  Patched {whl_path.name} SBOM: added file_name to PURL, renamed to redhat.spdx.json")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fromager produces fromager.spdx.json with no way to configure the filename. Rename it to redhat.spdx.json during the existing wheel rewrite that patches PURLs, avoiding an extra rewrite pass.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Rename the Fromager-generated SBOM inside built wheels to use a redhat.spdx.json filename during the existing wheel rewrite step.

New Features:
- Standardize the SBOM filename inside built wheels to redhat.spdx.json instead of the default Fromager output name.

Enhancements:
- Integrate SBOM filename renaming into the existing wheel rewrite process that already patches PURLs, avoiding an additional rewrite pass.