### PR TITLE
Add wheel cache authentication for build-wheels

### DIFF
--- a/builder/scripts/build-wheels
+++ b/builder/scripts/build-wheels
@@ -96,6 +96,20 @@ if [ -f "$ca_bundle" ]; then
     update-ca-trust
 fi
 
+log "Setting up netrc"
+NETRC=~/.netrc
+
+# Only write netrc if both SERVICE_ACCOUNT_USERNAME and SERVICE_ACCOUNT_PASSWORD are set.
+if [ -n "${SERVICE_ACCOUNT_USERNAME:-}" ] && [ -n "${SERVICE_ACCOUNT_PASSWORD:-}" ]; then
+    cat > "$NETRC" <<- EOM
+machine packages.redhat.com login ${SERVICE_ACCOUNT_USERNAME} password ${SERVICE_ACCOUNT_PASSWORD}
+EOM
+    chmod 0600 "$NETRC"
+    log "Wrote netrc for packages.redhat.com"
+else
+    log "SERVICE_ACCOUNT_USERNAME and/or SERVICE_ACCOUNT_PASSWORD not set - skipping netrc setup"
+fi
+
 log "Preparing build environment"
 rm -rf output
 mkdir output

--- a/tasks/build-python-wheels-oci-ta.yaml
+++ b/tasks/build-python-wheels-oci-ta.yaml
@@ -42,6 +42,11 @@ spec:
       description: Optional wheel server URL for prebuilt wheel lookup
       type: string
       default: ""
+    - name: SERVICE_ACCOUNT_SECRET_NAME
+      description: >-
+        Name of the K8s secret containing wheel cache server credentials (keys: username, password)
+      type: string
+      default: builder-service-account
   results:
     - name: IMAGE_DIGEST
       description: Digest of the OCI-Artifact just built
@@ -87,6 +92,17 @@ spec:
         - mountPath: /mnt/trusted-ca
           name: trusted-ca
           readOnly: true
+      env:
+        - name: SERVICE_ACCOUNT_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: $(params.SERVICE_ACCOUNT_SECRET_NAME)
+              key: username
+        - name: SERVICE_ACCOUNT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: $(params.SERVICE_ACCOUNT_SECRET_NAME)
+              key: password
       command:
         - build-wheels
       args:


### PR DESCRIPTION
Mount service account credentials and set up netrc so Fromager can authenticate with packages.redhat.com when checking the wheel cache, avoiding 403 errors and enabling faster builds from cached wheels.

## Summary by Sourcery

Add authenticated access to the wheel cache in the build-wheels task to enable using cached wheels from a credentials-protected server.

Enhancements:
- Introduce a configurable service account secret parameter and mount to supply wheel cache credentials to the build-wheels task.
- Expose service account username and password from the mounted secret as environment variables for the wheel-building container.