### PR TITLE
Update integration tests

### DIFF
--- a/tasks/install-and-import-wheels.yaml
+++ b/tasks/install-and-import-wheels.yaml
@@ -369,6 +369,20 @@ spec:
                         echo "SKIP: $WHEEL"
                     else
                         echo "FAIL: $WHEEL"
+                        python3.12 -c "
+        import json, sys
+        try:
+            with open(sys.argv[1]) as f:
+                d = json.load(f)
+            for t in d.get('imports_tested', []):
+                if not isinstance(t, dict) or t.get('success'):
+                    continue
+                name = t.get('name', '<unknown>')
+                message = t.get('message', '')
+                print(f'  {name}: {message}')
+        except Exception:
+            pass
+        " "$RESULT_FILE"
                     fi
                 fi
             fi
@@ -407,6 +421,23 @@ spec:
             R_REASON="${REST#*	}"
 
             printf "%-60s %-8s %s\n" "$R_WHEEL" "$R_STATUS" "$R_REASON"
+
+            if [ "$R_STATUS" = "FAIL" ]; then
+                python3.12 -c "
+        import json, sys
+        try:
+            with open(sys.argv[1]) as f:
+                d = json.load(f)
+            for t in d.get('imports_tested', []):
+                if not isinstance(t, dict) or t.get('success'):
+                    continue
+                name = t.get('name', '<unknown>')
+                message = t.get('message', '')
+                print(f'  -> {name}: {message}')
+        except Exception:
+            pass
+        " "$RESULT_FILE"
+            fi
 
             case "$R_STATUS" in
                 PASS) PASS_COUNT=$((PASS_COUNT + 1)) ;;

--- a/tasks/install-and-import-wheels.yaml
+++ b/tasks/install-and-import-wheels.yaml
@@ -209,7 +209,7 @@ spec:
 
             import_names = {
                 name for name in import_names
-                if not name.split('.')[0].startswith('_')
+                if not any(part.startswith('_') for part in name.split('.'))
                 and name != 'tests'
                 and not name.endswith('.libs')
                 and not name.startswith('pytest_')


### PR DESCRIPTION
* do not swallow failure logs
* fix underscore filtering during imports

## Summary by Sourcery

Improve wheel import integration tests and surface failures more clearly.

Bug Fixes:
- Fix import filtering to exclude any module path segment starting with an underscore instead of only the top-level name.

Enhancements:
- Print detailed per-module import failure messages when a wheel import test fails to make debugging easier.