### PR TITLE
Builder improvements

### DIFF
--- a/builder/Containerfile
+++ b/builder/Containerfile
@@ -205,6 +205,15 @@ RUN export OPENBLAS_VERSION=0.3.31 && \
     /opt/_internal/build_scripts/build-openblas.sh
 
 
+FROM build_base AS build_libomp
+COPY build_scripts/build-libomp.sh /opt/_internal/build_scripts/
+RUN export LIBOMP_VERSION=20.1.6 && \
+    export LIBOMP_HASH=ff8dabd89212cd41b4fc5c26433bcde368873e4f10ea0331792e6b6e7707eff9 && \
+    export LIBOMP_CMAKE_HASH=b4b3efa5d5b01b3f211f1ba326bb6f0c318331f828202d332c95b7f30fca5f8c && \
+    export LIBOMP_DOWNLOAD_URL=https://github.com/llvm/llvm-project/releases/download && \
+    /opt/_internal/build_scripts/build-libomp.sh
+
+
 FROM build_base AS build_zlib
 COPY build_scripts/build-zlib.sh /opt/_internal/build_scripts/
 RUN export ZLIB_VERSION=1.3.1 && \
@@ -273,6 +282,7 @@ COPY --from=build_libxml2 /manylinux-buildfs /
 COPY --from=build_libxslt /manylinux-buildfs /
 COPY --from=build_libffi /manylinux-buildfs /
 COPY --from=build_openblas /manylinux-buildfs /
+COPY --from=build_libomp /manylinux-buildfs /
 ARG MANYLINUX_DISABLE_CLANG_FOR_CPYTHON
 RUN --mount=type=bind,from=static_clang,target=/tmp/cross-compiler,ro \
     /tmp/cross-compiler/entrypoint /opt/_internal/build_scripts/build-cpython.sh thomas@python.org https://accounts.google.com 3.12.12
@@ -289,6 +299,7 @@ COPY --from=build_libxml2 /manylinux-buildfs /
 COPY --from=build_libxslt /manylinux-buildfs /
 COPY --from=build_libffi /manylinux-buildfs /
 COPY --from=build_openblas /manylinux-buildfs /
+COPY --from=build_libomp /manylinux-buildfs /
 
 
 FROM runtime_base
@@ -308,6 +319,7 @@ COPY --from=build_libxml2 /manylinux-rootfs /
 COPY --from=build_libxslt /manylinux-rootfs /
 COPY --from=build_libffi /manylinux-rootfs /
 COPY --from=build_openblas /manylinux-rootfs /
+COPY --from=build_libomp /manylinux-rootfs /
 RUN find /opt/_internal -name '*.so' -printf '%h\n' | sort -u >> /etc/ld.so.conf.d/00-manylinux.conf && \
     ldconfig
 
@@ -316,13 +328,13 @@ COPY --from=merged_buildfs /opt /opt
 COPY --from=merged_buildfs /usr/local/lib/pkgconfig /usr/local/lib/pkgconfig
 # Create symlinks in standard paths so build systems that don't use pkg-config
 # (e.g. PyYAML's setup.py) can find our source-built headers and libraries
-RUN for dir in /opt/_internal/lib*/include /opt/_internal/openblas*/include /opt/_internal/zlib*/include /opt/_internal/bzip2*/include; do \
+RUN for dir in /opt/_internal/lib*/include /opt/_internal/openblas*/include /opt/_internal/zlib*/include /opt/_internal/bzip2*/include /opt/_internal/libomp*/include; do \
         [ -d "$dir" ] || continue; \
         for item in "$dir"/*; do \
             ln -sf "$item" /usr/local/include/; \
         done; \
     done && \
-    for dir in /opt/_internal/lib*/lib /opt/_internal/openblas*/lib /opt/_internal/zlib*/lib /opt/_internal/bzip2*/lib; do \
+    for dir in /opt/_internal/lib*/lib /opt/_internal/openblas*/lib /opt/_internal/zlib*/lib /opt/_internal/bzip2*/lib /opt/_internal/libomp*/lib; do \
         [ -d "$dir" ] || continue; \
         for lib in "$dir"/lib*.so; do \
             [ -f "$lib" ] && ln -sf "$lib" /usr/local/lib/; \

--- a/builder/Containerfile
+++ b/builder/Containerfile
@@ -145,7 +145,7 @@ RUN --mount=type=bind,from=static_clang,target=/tmp/cross-compiler,ro \
 FROM build_base AS build_rust
 COPY build_scripts/build-rust.sh /opt/_internal/build_scripts/
 RUN --mount=type=bind,from=static_clang,target=/tmp/cross-compiler,ro \
-    export RUST_VERSION=1.94.0 && \
+    export RUST_VERSION=1.95.0 && \
     export RUST_HASH=4acc9acc76d5079515b46346a485974457b5a79893cfb01112423c89aeb5aa10 && \
     export RUST_DOWNLOAD_URL=https://static.rust-lang.org/rustup/dist && \
     /tmp/cross-compiler/entrypoint /opt/_internal/build_scripts/build-rust.sh

--- a/builder/build_scripts/build-libomp.sh
+++ b/builder/build_scripts/build-libomp.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Top-level build script called from Dockerfile
+
+# Stop at any error, show all commands
+set -exuo pipefail
+
+# Get script directory
+MY_DIR=$(dirname "${BASH_SOURCE[0]}")
+
+# Get build utilities
+# shellcheck source-path=SCRIPTDIR
+source "${MY_DIR}/build_utils.sh"
+
+# Build libomp (LLVM OpenMP runtime)
+check_var "${LIBOMP_VERSION}"
+check_var "${LIBOMP_HASH}"
+check_var "${LIBOMP_CMAKE_HASH}"
+check_var "${LIBOMP_DOWNLOAD_URL}"
+LIBOMP_ROOT="openmp-${LIBOMP_VERSION}.src"
+LLVM_CMAKE_ROOT="cmake-${LIBOMP_VERSION}.src"
+
+PREFIX=/opt/_internal/libomp-${LIBOMP_VERSION%%.*}
+
+# Python3 is required by libomp's cmake build to generate string tables
+manylinux_pkg_install python3
+
+fetch_source "${LIBOMP_ROOT}.tar.xz" "${LIBOMP_DOWNLOAD_URL}/llvmorg-${LIBOMP_VERSION}"
+check_sha256sum "${LIBOMP_ROOT}.tar.xz" "${LIBOMP_HASH}"
+fetch_source "${LLVM_CMAKE_ROOT}.tar.xz" "${LIBOMP_DOWNLOAD_URL}/llvmorg-${LIBOMP_VERSION}"
+check_sha256sum "${LLVM_CMAKE_ROOT}.tar.xz" "${LIBOMP_CMAKE_HASH}"
+tar xf "${LIBOMP_ROOT}.tar.xz"
+tar xf "${LLVM_CMAKE_ROOT}.tar.xz"
+pushd "${LIBOMP_ROOT}"
+
+# Build with CMake (standalone build requires LLVM cmake modules)
+mkdir build
+cd build
+cmake .. \
+    -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_FLAGS="${MANYLINUX_CFLAGS}" \
+    -DCMAKE_CXX_FLAGS="${MANYLINUX_CXXFLAGS}" \
+    -DCMAKE_INSTALL_LIBDIR=lib \
+    -DOPENMP_STANDALONE_BUILD=ON \
+    -DLIBOMP_INSTALL_ALIASES=ON \
+    -DLIBOMP_OMPD_GDB_SUPPORT=OFF \
+    -DOPENMP_ENABLE_LIBOMPTARGET=OFF \
+    -DCMAKE_MODULE_PATH="$(pwd)/../../${LLVM_CMAKE_ROOT}/Modules" \
+    > /dev/null
+
+make -j"$(nproc)" > /dev/null
+make install DESTDIR=/manylinux-rootfs > /dev/null
+popd
+rm -rf "${LIBOMP_ROOT}" "${LIBOMP_ROOT}.tar.xz" "${LLVM_CMAKE_ROOT}" "${LLVM_CMAKE_ROOT}.tar.xz"
+
+# Strip what we can
+strip_ /manylinux-rootfs
+
+# Install for build
+mkdir /manylinux-buildfs
+cp -rlf /manylinux-rootfs/* /manylinux-buildfs/
+
+# Clean-up for runtime (keep libs and omp.h, remove cmake config)
+rm -rf /manylinux-rootfs"${PREFIX}"/lib/cmake

--- a/builder/scripts/build-wheels
+++ b/builder/scripts/build-wheels
@@ -171,7 +171,17 @@ for PACKAGE in "${PACKAGES[@]}"; do
 
     if [ -n "$(find wheels-repo/downloads -name '*linux_x86_64.whl' | head -1)" ]; then
         log manylinux wheels have been found, auditwheel step required
+
+        # Extract shared libraries from wheels so auditwheel can find
+        # wheel-internal libs (e.g. pyre's libjournal.so) during repair.
+        wheel_libs_dir=$(mktemp -d)
+        for whl in wheels-repo/downloads/*linux_x86_64.whl; do
+            unzip -joq "$whl" '*.so' '*.so.*' -d "$wheel_libs_dir" 2>/dev/null || true
+        done
+        export LD_LIBRARY_PATH="${wheel_libs_dir}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
         auditwheel repair wheels-repo/downloads/*linux_x86_64.whl -w wheels-repo/downloads
+        rm -rf "$wheel_libs_dir"
 
         # auditwheel >= 6.5 embeds CycloneDX SBOMs in repaired wheels by default.
         # Remove only auditwheel's SBOMs (*.cdx.json) and leave Fromager's intact.


### PR DESCRIPTION
* Updated rust to 1.95.0
* Build libomp from source
* Expose wheel-internal shared libs to auditwheel repair

JIRA: CALUNGA-258

## Summary by Sourcery

Update the manylinux builder to use a newer Rust toolchain and include a source-built libomp runtime in both build and runtime images.

New Features:
- Add a build stage and script to compile and install libomp (LLVM OpenMP runtime) from source into the manylinux images.

Enhancements:
- Upgrade the Rust toolchain used in the builder image from 1.94.0 to 1.95.0.
- Expose libomp headers and shared libraries in standard include and library paths so they are available to builds and auditwheel repair.