### PR TITLE
CALUNGA-268: Increase builder build-container resources from 4.6cpu/8…

### DIFF
--- a/.tekton/plumbing-builder-pull-request.yaml
+++ b/.tekton/plumbing-builder-pull-request.yaml
@@ -34,6 +34,7 @@ spec:
     pipeline: 3h
   taskRunSpecs:
     - pipelineTaskName: build-container
+      timeout: 3h
       stepSpecs:
         - name: build
           computeResources:

--- a/.tekton/plumbing-builder-pull-request.yaml
+++ b/.tekton/plumbing-builder-pull-request.yaml
@@ -30,6 +30,19 @@ spec:
       value: Containerfile
     - name: path-context
       value: builder
+  timeouts:
+    pipeline: 3h
+  taskRunSpecs:
+    - pipelineTaskName: build-container
+      stepSpecs:
+        - name: build
+          computeResources:
+            requests:
+              cpu: '8'
+              memory: 12Gi
+            limits:
+              cpu: '8'
+              memory: 12Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-plumbing-builder
   workspaces:

--- a/.tekton/plumbing-builder-push.yaml
+++ b/.tekton/plumbing-builder-push.yaml
@@ -27,6 +27,19 @@ spec:
       value: Containerfile
     - name: path-context
       value: builder
+  timeouts:
+    pipeline: 3h
+  taskRunSpecs:
+    - pipelineTaskName: build-container
+      stepSpecs:
+        - name: build
+          computeResources:
+            requests:
+              cpu: '8'
+              memory: 12Gi
+            limits:
+              cpu: '8'
+              memory: 12Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-plumbing-builder
   workspaces:

--- a/.tekton/plumbing-builder-push.yaml
+++ b/.tekton/plumbing-builder-push.yaml
@@ -31,6 +31,7 @@ spec:
     pipeline: 3h
   taskRunSpecs:
     - pipelineTaskName: build-container
+      timeout: 3h
       stepSpecs:
         - name: build
           computeResources:


### PR DESCRIPTION
…Gi to 8cpu/12Gi and pipeline timeout from 2h to 3h

## Summary by Sourcery

Increase Tekton plumbing builder pipelines resource allocation and execution timeout for container build steps.

Build:
- Raise pipeline timeout to 3 hours for plumbing-builder pull request and push Tekton pipelines.
- Increase CPU and memory requests/limits for the build-container step in plumbing-builder pull request and push Tekton pipelines to 8 CPU and 12Gi RAM.