### PR TITLE
Improve push-py-pulp error handling and upload visibility

### DIFF
--- a/utils/scripts/pulp-upload
+++ b/utils/scripts/pulp-upload
@@ -16,9 +16,15 @@ PULP_REPOSITORY_VERSION=$( curl --fail --silent --retry 3 --max-time 30 "${PULP_
 
 shopt -s nullglob
 
+uploaded=()
+skipped_existing=()
+skipped_no_attestation=()
+failed=()
+
 for file in *.whl *.tar.gz; do
     if [[ ! -f "${file}.attestation" ]]; then
         echo "Skipping $file - attestation file missing"
+        skipped_no_attestation+=("$file")
         continue
     fi
 
@@ -28,15 +34,47 @@ for file in *.whl *.tar.gz; do
         --data-urlencode "repository_version=${PULP_REPOSITORY_VERSION}" | jq '.results | length != 0' )
     if $WHEEL_EXISTS; then
         echo "Skipping ${file} - already exists in Pulp"
+        skipped_existing+=("$file")
         continue
     fi
 
-    if ! twine upload --non-interactive --verbose --repository-url "${REPOSITORY_URL}" --attestations $file "${file}.attestation"; then
-        echo "Failed to upload $file with attestation, skipping."
-        continue
+    if twine upload --non-interactive --verbose --disable-progress-bar --repository-url "${REPOSITORY_URL}" --attestations $file "${file}.attestation"; then
+        echo "Uploaded $file with attestation."
+        uploaded+=("$file")
+    else
+        echo "ERROR: Failed to upload $file"
+        failed+=("$file")
     fi
-    echo "Uploaded $file with attestation."
 done
 
-echo "Upload complete!"
+echo ""
+echo "=============================="
+echo "  Upload Summary"
+echo "=============================="
+echo ""
+echo "Uploaded (${#uploaded[@]}):"
+for f in "${uploaded[@]+"${uploaded[@]}"}"; do
+    echo "  - $f"
+done
+echo ""
+echo "Skipped - already in Pulp (${#skipped_existing[@]}):"
+for f in "${skipped_existing[@]+"${skipped_existing[@]}"}"; do
+    echo "  - $f"
+done
+echo ""
+echo "Skipped - missing attestation (${#skipped_no_attestation[@]}):"
+for f in "${skipped_no_attestation[@]+"${skipped_no_attestation[@]}"}"; do
+    echo "  - $f"
+done
+echo ""
+echo "Failed (${#failed[@]}):"
+for f in "${failed[@]+"${failed[@]}"}"; do
+    echo "  - $f"
+done
+echo ""
 echo "Index URL: ${REPOSITORY_URL}"
+
+if [[ ${#failed[@]} -gt 0 ]]; then
+    echo "ERROR: ${#failed[@]} upload(s) failed"
+    exit 1
+fi

--- a/utils/scripts/pulp-upload
+++ b/utils/scripts/pulp-upload
@@ -74,7 +74,7 @@ done
 echo ""
 echo "Index URL: ${REPOSITORY_URL}"
 
-if [[ ${#failed[@]} -gt 0 ]]; then
-    echo "ERROR: ${#failed[@]} upload(s) failed"
+if [[ ${#failed[@]} -gt 0 || ${#skipped_no_attestation[@]} -gt 0 ]]; then
+    echo "ERROR: ${#failed[@]} upload(s) failed, ${#skipped_no_attestation[@]} file(s) missing attestation"
     exit 1
 fi


### PR DESCRIPTION
- Add --disable-progress-bar to twine upload to reduce log noise in CI
- Track upload outcomes (uploaded, skipped, failed) and print a summary at the end of the task for quick at-a-glance results
- Fail the task with exit code 1 when any upload fails, preventing silent failures where the task reports success despite failed uploads

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Improve the pulp-upload script’s package upload reporting and robustness.

New Features:
- Add a summary of upload outcomes (uploaded, skipped, failed) at the end of the pulp-upload task for quick visibility.

Bug Fixes:
- Ensure the pulp-upload task exits with a non-zero status when any upload fails to avoid silent failures.

Enhancements:
- Silence the progress bar in twine uploads during CI to reduce log noise.