### PR TITLE
chore(CALUNGA-246): add CPU resource limits to build-wheels task

### DIFF
--- a/tasks/build-python-wheels-oci-ta.yaml
+++ b/tasks/build-python-wheels-oci-ta.yaml
@@ -67,10 +67,11 @@ spec:
   stepTemplate:
     computeResources:
       limits:
+        cpu: "4"
         memory: 4Gi
       requests:
-        cpu: "1"
-        memory: 1Gi
+        cpu: "4"
+        memory: 4Gi
     volumeMounts:
       - mountPath: /var/workdir
         name: workdir


### PR DESCRIPTION
Untrusted upstream setup.py scripts execute in a shared pod, so a
resource-exhaustive package could monopolize the node.

Add explicit CPU limit (4 cores) and align requests with limits to
enforce [Guaranteed QoS class](https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/#guaranteed).

Addresses `CTRL-005.03`.

JIRA: [CALUNGA-246](https://redhat.atlassian.net/browse/CALUNGA-246)

Assisted-by: Claude

## Summary by Sourcery

Build:
- Raise CPU and memory requests for the build-python-wheels-oci-ta task to allocate more resources during builds.