### PR TITLE
Add trusted_task_rules for build-python-wheels-oci-ta

### DIFF
--- a/policy-data/trusted_task_rules.yaml
+++ b/policy-data/trusted_task_rules.yaml
@@ -1,0 +1,11 @@
+---
+# CTRL-004: Register build-python-wheels-oci-ta as a trusted task in Enterprise Contract.
+#
+# This file is referenced as a data source in Calunga's EC policies so that
+# Conforma can verify the build task without maintaining a separate
+# data-acceptable-bundles OCI artifact.  See ADR 0053 for background:
+# https://konflux-ci.dev/architecture/ADR/0053-trusted-task-model/
+trusted_task_rules:
+  allow:
+    calunga-build-tasks:
+      - pattern: oci://quay.io/redhat-user-workloads/calunga-tenant/task-build-python-wheels*


### PR DESCRIPTION
Register the Calunga build task as a trusted task in Enterprise Contract via the trusted_task_rules mechanism (ADR 0053). EC policies reference this file as a data source to verify builder identity without requiring a separate data-acceptable-bundles OCI artifact.

## Summary by Sourcery

Enhancements:
- Define a trusted_task_rules YAML data source allowing the calunga-build-tasks pattern for the build-python-wheels OCI task so EC policies can verify the builder without a separate acceptable-bundles artifact.