### PR TITLE
Adding plumbing for npm builder image

### DIFF
--- a/.tekton/README.md
+++ b/.tekton/README.md
@@ -42,8 +42,11 @@ There is a dependency between the `Components`. For example, the builder image i
 build-python-wheels task. A change in the builder image requires not only building a new image, but
 also building a new Tekton bundle for that `Task` that uses the new builder image.
 
+The `npm-builder` image is built the same way as `plumbing-builder` and will be referenced by
+`build-npm-package` Tekton tasks in a later POC phase.
+
 The `Components` use [nudges](https://konflux-ci.dev/docs/building/component-nudges/#what-is-nudged)
 to keep these dependencies up to date. If all is working as expected, Konflux should
-generate pull requests to these `Component` dependencies up to date. In the example above, after
+generate pull requests to keep these `Component` dependencies up to date. In the example above, after
 a new builder image is built, a pull request should be automatically created to update the `Task`
 definition.

--- a/.tekton/npm-builder-pull-request.yaml
+++ b/.tekton/npm-builder-pull-request.yaml
@@ -1,0 +1,41 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/calungaproject/plumbing?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && ( "npm-builder/***".pathChanged() || ".tekton/npm-builder-pull-request.yaml".pathChanged() )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: calunga-v2
+    appstudio.openshift.io/component: npm-builder
+    pipelines.appstudio.openshift.io/type: build
+  name: npm-builder-on-pull-request
+  namespace: calunga-tenant
+spec:
+  params:
+    - name: git-url
+      value: '{{source_url}}'
+    - name: revision
+      value: '{{revision}}'
+    - name: output-image
+      value: quay.io/redhat-user-workloads/calunga-tenant/npm-builder:on-pr-{{revision}}
+    - name: image-expires-after
+      value: 5d
+    - name: dockerfile
+      value: Containerfile
+    - name: path-context
+      value: npm-builder
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-npm-builder
+  workspaces:
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'
+  pipelineRef:
+    name: build
+status: {}

--- a/.tekton/npm-builder-push.yaml
+++ b/.tekton/npm-builder-push.yaml
@@ -1,0 +1,38 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/calungaproject/plumbing?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && ( "npm-builder/***".pathChanged() || ".tekton/npm-builder-push.yaml".pathChanged() )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: calunga-v2
+    appstudio.openshift.io/component: npm-builder
+    pipelines.appstudio.openshift.io/type: build
+  name: npm-builder-on-push
+  namespace: calunga-tenant
+spec:
+  params:
+    - name: git-url
+      value: '{{source_url}}'
+    - name: revision
+      value: '{{revision}}'
+    - name: output-image
+      value: quay.io/redhat-user-workloads/calunga-tenant/npm-builder:{{revision}}
+    - name: dockerfile
+      value: Containerfile
+    - name: path-context
+      value: npm-builder
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-npm-builder
+  workspaces:
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'
+  pipelineRef:
+    name: build
+status: {}

--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ The [builder](./builder) directory contains everything needed to build a contain
 - Handle CA trust configuration for enterprise environments
 - Output both wheels and source distributions
 
+### npm Builder Image
+
+The [npm-builder](./npm-builder) directory contains the factory image for npm Trusted Libraries onboarding:
+
+- Node.js 20 LTS on UBI 8 (glibc, linux-x64)
+- Go, **Rust (Red Hat rust-toolset)**, and build tools for Tier B/C packages (esbuild, napi-rs, etc.)
+- Factory scripts (`build-npm-package`, `collect-npm-artifacts`) used by Tekton tasks
+
+Published to Quay as `npm-builder` via Konflux component `npm-builder`.
+
 ## Utils Image
 
 The [utils](./utils) directory is the source for the calunga utils image. This image is used for

--- a/npm-builder/Containerfile
+++ b/npm-builder/Containerfile
@@ -1,0 +1,62 @@
+# TL npm factory builder — linux-x64, glibc (UBI8), Node 20 LTS + Go + Rust.
+# Used by Konflux build-npm-package tasks; onboarder recipes run via build-npm-package.
+# Keep ARG BASEIMAGE in sync with baseimage.lock.
+ARG BASEIMAGE=registry.access.redhat.com/ubi8/ubi@sha256:28a85f76ad1ea0a46a81a934b02fff48d75541f77777be403d48b6bb99a363ad
+
+FROM ${BASEIMAGE}
+
+LABEL maintainer="Red Hat Trusted Libraries"
+LABEL io.k8s.description="npm TL factory builder (Node 20, Go, Rust, glibc)"
+LABEL org.opencontainers.image.source="https://github.com/calungaproject/plumbing"
+
+ENV LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US.UTF-8 \
+    NODE_ENV=production \
+    NPM_CONFIG_UPDATE_NOTIFIER=false
+
+RUN dnf -y module enable nodejs:20 && \
+    dnf -y install \
+        --setopt install_weak_deps=0 \
+        glibc-langpack-en \
+        nodejs \
+        npm \
+        git \
+        golang \
+        python3 \
+        python3-pip \
+        ca-certificates \
+        tar \
+        gzip \
+        xz \
+        jq \
+        which \
+        findutils \
+        patch \
+        make \
+        gcc \
+        gcc-c++ \
+        pkg-config \
+        openssl-devel \
+        && dnf clean all \
+        && rm -rf /var/cache/dnf
+
+# Rust version pin: edit rust-toolset.lock only (single source of truth).
+COPY rust-toolset.lock build_scripts/install-rust-toolset.sh /tmp/
+RUN chmod +x /tmp/install-rust-toolset.sh && \
+    RUST_TOOLSET_LOCK=/tmp/rust-toolset.lock /tmp/install-rust-toolset.sh && \
+    rm -f /tmp/install-rust-toolset.sh /tmp/rust-toolset.lock && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
+
+RUN useradd -m -u 1001 -s /bin/bash builder
+
+COPY --chmod=755 scripts/build-npm-package scripts/collect-npm-artifacts /usr/local/bin/
+
+# rust-toolset + llvm-toolset (dependency) install under /opt/rh/* — same as `scl enable`.
+ENV PATH="/opt/rh/rust-toolset/root/usr/bin:/opt/rh/llvm-toolset/root/usr/bin:/usr/local/bin:${PATH}"
+
+WORKDIR /work
+USER builder
+
+CMD ["bash"]

--- a/npm-builder/README.md
+++ b/npm-builder/README.md
@@ -1,0 +1,83 @@
+# npm builder image
+
+Container image for the npm Trusted Libraries factory. Runs onboarder recipes
+(`build.entrypoint.sh`, `verify.smoke.sh`) inside Konflux build tasks.
+
+## Toolchain (v1)
+
+All packages from **UBI 8 repositories** (AppStream/BaseOS) — no rustup or
+downloads from `static.rust-lang.org`.
+
+| Tool | Source | Pinning |
+| ---- | ------ | ------- |
+| UBI 8 base | `registry.access.redhat.com/ubi8/ubi` | digest in [`baseimage.lock`](./baseimage.lock) + Containerfile `ARG BASEIMAGE` |
+| Node.js 20 LTS | AppStream `nodejs:20` module | stream `20` |
+| Go | AppStream `golang` | distro default |
+| **Rust** | AppStream **`rust-toolset`** module | **exact RPM VR** in [`rust-toolset.lock`](./rust-toolset.lock) |
+| C/C++ / node-gyp | `gcc`, `python3`, `openssl-devel`, etc. | — |
+
+### Rust pinning (RHEL 8)
+
+Unlike `nodejs:20`, **`rust-toolset` is a rolling Application Stream** — Red Hat
+rebases the single module in place. There is no `dnf module install rust-toolset:1.84`
+stream selector.
+
+**Edit [`rust-toolset.lock`](./rust-toolset.lock) for Rust** — the Containerfile and
+install script read `RUST_VERSION` and `RUST_VR` from there. UBI rust-toolset RPMs
+use epoch `(none)`; we pin by installing exact version-release specs, then
+`dnf versionlock`.
+
+**Edit [`baseimage.lock`](./baseimage.lock) when bumping UBI** — keep the same
+digest in Containerfile `ARG BASEIMAGE` (required before `FROM`; buildkit cannot
+read the lock file into that line).
+
+To refresh the lock file from current UBI (uses `baseimage.lock` as the query image).
+Requires `docker` on the host (`CONTAINER_RUNTIME=podman` also works):
+
+```bash
+./hack/update-rust-toolset-lock.sh
+```
+
+Or query manually, then update `rust-toolset.lock` by hand:
+
+```bash
+docker run --rm --platform linux/amd64 "$(grep BASEIMAGE= baseimage.lock | cut -d= -f2-)" bash -c \
+  'dnf -y module install rust-toolset && rpm -q rust cargo rust-std-static rust-toolset'
+```
+
+**Caveat:** UBI CDN may eventually drop older module RPMs after a rebase. If a
+pinned VR disappears, the image build fails until you bump `rust-toolset.lock` —
+that is intentional.
+
+The Python `plumbing-builder` uses **rustup** from the internet for a specific
+version; this npm image deliberately uses **Red Hat RPMs only**.
+
+## Quay
+
+Built by Konflux component `npm-builder` under application `calunga-v2`:
+
+```text
+quay.io/redhat-user-workloads/calunga-tenant/npm-builder:<tag>
+```
+
+## Scripts
+
+| Script | Role |
+| ------ | ---- |
+| `build-npm-package` | Run entrypoint + smoke for one manifest |
+| `collect-npm-artifacts` | Stage `out/*.tgz` for OCI / publish steps |
+| `build_scripts/install-rust-toolset.sh` | Install + versionlock pinned rust-toolset RPMs |
+
+Publishing to Pulp and cosign are handled in **Tekton steps**, not in these scripts.
+
+## Local build
+
+Requires `docker` on the host (`CONTAINER_RUNTIME=podman ./hack/update-rust-toolset-lock.sh` for lock refresh only).
+
+```bash
+docker build -t npm-builder -f Containerfile .
+docker run --rm npm-builder node --version
+docker run --rm npm-builder go version
+docker run --rm npm-builder rustc --version
+docker run --rm npm-builder cargo --version
+```

--- a/npm-builder/baseimage.lock
+++ b/npm-builder/baseimage.lock
@@ -1,0 +1,2 @@
+# UBI base for npm-builder — must match Containerfile ARG BASEIMAGE (before FROM).
+BASEIMAGE=registry.access.redhat.com/ubi8/ubi@sha256:28a85f76ad1ea0a46a81a934b02fff48d75541f77777be403d48b6bb99a363ad

--- a/npm-builder/build_scripts/install-rust-toolset.sh
+++ b/npm-builder/build_scripts/install-rust-toolset.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Install pinned rust-toolset RPMs from UBI AppStream (no rust-lang.org).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOCK_FILE="${RUST_TOOLSET_LOCK:-${SCRIPT_DIR}/../rust-toolset.lock}"
+
+if [[ -f "${LOCK_FILE}" ]]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "${LOCK_FILE}"
+    set +a
+fi
+
+RUST_VERSION="${RUST_VERSION:?RUST_VERSION required (set in ${LOCK_FILE})}"
+RUST_VR="${RUST_VR:?RUST_VR required (set in ${LOCK_FILE})}"
+
+# rust-toolset is a rolling AppStream module (not nodejs:20-style version streams).
+# Pin by exact RPM version-release (epoch is always none on UBI rust-toolset).
+dnf -y module enable rust-toolset
+
+dnf -y install \
+    --setopt install_weak_deps=0 \
+    "rust-toolset-${RUST_VR}" \
+    "rust-${RUST_VR}" \
+    "cargo-${RUST_VR}" \
+    "rust-std-static-${RUST_VR}"
+
+if ! rustc --version | grep -Fq "${RUST_VERSION}"; then
+    echo "rustc version mismatch: expected ${RUST_VERSION}" >&2
+    rustc --version >&2 || true
+    exit 1
+fi
+
+# Prevent accidental upgrades when the rolling module moves (e.g. 1.84 → 1.88).
+dnf -y install dnf-plugin-versionlock
+dnf versionlock add \
+    "rust-toolset-${RUST_VR}" \
+    "rust-${RUST_VR}" \
+    "cargo-${RUST_VR}" \
+    "rust-std-static-${RUST_VR}"
+
+echo "Installed and locked rust-toolset ${RUST_VERSION} (${RUST_VR})"
+rustc --version
+cargo --version

--- a/npm-builder/hack/update-rust-toolset-lock.sh
+++ b/npm-builder/hack/update-rust-toolset-lock.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Refresh rust-toolset.lock from UBI AppStream (linux/amd64).
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOCK_FILE="${ROOT_DIR}/rust-toolset.lock"
+BASEIMAGE_LOCK="${ROOT_DIR}/baseimage.lock"
+PLATFORM="${PLATFORM:-linux/amd64}"
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
+
+if [[ -f "${BASEIMAGE_LOCK}" ]]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "${BASEIMAGE_LOCK}"
+    set +a
+fi
+BASEIMAGE="${BASEIMAGE:?BASEIMAGE required — set in baseimage.lock or env}"
+
+read -r RUST_VERSION RUST_VR < <(
+    "${CONTAINER_RUNTIME}" run --rm --platform "${PLATFORM}" "${BASEIMAGE}" bash -c '
+        set -euo pipefail
+        dnf -y -q module install rust-toolset
+        # UBI rust-toolset RPMs use epoch (none); version-release is sufficient for dnf.
+        echo "$(rpm -q --qf "%\{VERSION\}" rust) $(rpm -q --qf "%\{VERSION\}-%\{RELEASE\}" rust)"
+    '
+)
+
+cat > "${LOCK_FILE}" <<EOF
+# Single source of truth for pinned rust-toolset RPMs (UBI AppStream only).
+# Base image digest: see baseimage.lock (must match Containerfile ARG BASEIMAGE).
+#
+# To upgrade Rust:
+#   1. Ensure baseimage.lock matches Containerfile, then run:
+#        hack/update-rust-toolset-lock.sh
+#   2. Rebuild the npm-builder image.
+RUST_VERSION=${RUST_VERSION}
+RUST_VR=${RUST_VR}
+EOF
+
+echo "Using BASEIMAGE=${BASEIMAGE} (${CONTAINER_RUNTIME})"
+echo "Updated ${LOCK_FILE}:"
+grep -E '^RUST_' "${LOCK_FILE}"

--- a/npm-builder/rust-toolset.lock
+++ b/npm-builder/rust-toolset.lock
@@ -1,0 +1,6 @@
+# Pinned rust-toolset RPMs from UBI AppStream (Red Hat only — no rustup).
+# Base image: baseimage.lock (must match Containerfile ARG BASEIMAGE).
+# Bump when intentionally upgrading; image build fails if VR leaves the CDN.
+# Epoch is always (none) on UBI rust-toolset RPMs — RUST_VR is version-release only.
+RUST_VERSION=1.92.0
+RUST_VR=1.92.0-1.module+el8.10.0+23854+aa7622f9

--- a/npm-builder/scripts/build-npm-package
+++ b/npm-builder/scripts/build-npm-package
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Factory orchestrator: run onboarder build.entrypoint.sh and verify.smoke.sh.
+# Invoked from Tekton; must not publish or hold registry credentials.
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: build-npm-package --manifest <path> [--workdir <dir>]
+
+Environment (set by Tekton):
+  MANIFEST_PATH     Path to manifest.json
+  PACKAGE_DIR       Directory containing manifest + scripts
+  SOURCE_DIR        Checkout of source.ref (optional; entrypoint may clone)
+  OUT_DIR           Output directory for tarballs (default: ${PACKAGE_DIR}/out)
+EOF
+}
+
+MANIFEST_PATH="${MANIFEST_PATH:-}"
+PACKAGE_DIR="${PACKAGE_DIR:-}"
+WORK_DIR="${WORK_DIR:-/work}"
+OUT_DIR="${OUT_DIR:-}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --manifest) MANIFEST_PATH="$2"; shift 2 ;;
+        --workdir) WORK_DIR="$2"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown argument: $1" >&2; usage; exit 2 ;;
+    esac
+done
+
+if [[ -z "${MANIFEST_PATH}" ]]; then
+    echo "MANIFEST_PATH or --manifest is required" >&2
+    exit 2
+fi
+
+PACKAGE_DIR="${PACKAGE_DIR:-$(dirname "${MANIFEST_PATH}")}"
+OUT_DIR="${OUT_DIR:-${PACKAGE_DIR}/out}"
+mkdir -p "${OUT_DIR}"
+
+ENTRYPOINT="${PACKAGE_DIR}/build.entrypoint.sh"
+SMOKE="${PACKAGE_DIR}/verify.smoke.sh"
+
+for script in "${ENTRYPOINT}" "${SMOKE}"; do
+    if [[ ! -x "${script}" ]]; then
+        echo "Required script missing or not executable: ${script}" >&2
+        exit 1
+    fi
+done
+
+export PACKAGE_DIR OUT_DIR WORK_DIR MANIFEST_PATH
+
+echo "[build-npm-package] Running ${ENTRYPOINT}"
+( cd "${PACKAGE_DIR}" && ./build.entrypoint.sh )
+
+echo "[build-npm-package] Running ${SMOKE}"
+( cd "${PACKAGE_DIR}" && ./verify.smoke.sh )
+
+echo "[build-npm-package] Done"

--- a/npm-builder/scripts/collect-npm-artifacts
+++ b/npm-builder/scripts/collect-npm-artifacts
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Collect factory outputs and logs for SBOM / OCI artifact packaging.
+set -euo pipefail
+
+ARTIFACT_DIR="${1:-}"
+OUTPUT_DIR="${2:-/var/workdir/artifact}"
+
+if [[ -z "${ARTIFACT_DIR}" ]]; then
+    echo "Usage: collect-npm-artifacts <source-dir> [output-dir]" >&2
+    exit 2
+fi
+
+mkdir -p "${OUTPUT_DIR}"
+shopt -s nullglob
+for path in "${ARTIFACT_DIR}"/*.tgz "${ARTIFACT_DIR}"/**/*.tgz; do
+    [[ -f "${path}" ]] || continue
+    rel="${path#${ARTIFACT_DIR}/}"
+    dest="${OUTPUT_DIR}/${rel}"
+    mkdir -p "$(dirname "${dest}")"
+    cp -a "${path}" "${dest}"
+done
+
+echo "[collect-npm-artifacts] Collected artifacts under ${OUTPUT_DIR}"


### PR DESCRIPTION
Adding npm builder image and its corresponding tekton PipelineRuns

## Summary by Sourcery

Add an npm-focused builder image and integrate it into the existing Konflux/Tekton build plumbing.

New Features:
- Introduce an npm builder image based on UBI 8 with Node.js 20, Go, Rust, and build tooling for Trusted Libraries onboarding.
- Provide factory scripts for building npm packages and collecting artifacts within the npm builder image.
- Add Tekton PipelineRun configurations to build the npm builder image on pull requests and pushes.

Enhancements:
- Document the npm builder image, its toolchain, and local build workflow in the main and per-image READMEs.
- Add scripts and lock files to pin and manage the npm builder base image and rust-toolset versions via UBI AppStream RPMs.
- Clarify Tekton component dependency and nudge behavior in the CI README.