### PR TITLE
Adding artifacts needed to implement npm on-pr event

### DIFF
--- a/.tekton/README.md
+++ b/.tekton/README.md
@@ -42,8 +42,9 @@ There is a dependency between the `Components`. For example, the builder image i
 build-python-wheels task. A change in the builder image requires not only building a new image, but
 also building a new Tekton bundle for that `Task` that uses the new builder image.
 
-The `npm-builder` image is built the same way as `plumbing-builder` and will be referenced by
-`build-npm-package` Tekton tasks in a later POC phase.
+The `npm-builder` image is built the same way as `plumbing-builder`. The Tekton task
+`build-npm-package-oci-ta` (component `task-build-npm-package`) is consumed by the
+`npm-registry` onboarding repo.
 
 The `Components` use [nudges](https://konflux-ci.dev/docs/building/component-nudges/#what-is-nudged)
 to keep these dependencies up to date. If all is working as expected, Konflux should

--- a/.tekton/task-build-npm-package-pull-request.yaml
+++ b/.tekton/task-build-npm-package-pull-request.yaml
@@ -1,0 +1,41 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/calungaproject/plumbing?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && ( "tasks/build-npm-package-oci-ta.yaml".pathChanged() || ".tekton/task-build-npm-package-pull-request.yaml".pathChanged() || ".tekton/bundle-build-pipeline.yaml".pathChanged() )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: calunga-v2
+    appstudio.openshift.io/component: task-build-npm-package
+    pipelines.appstudio.openshift.io/type: build
+  name: task-build-npm-package-on-pull-request
+  namespace: calunga-tenant
+spec:
+  params:
+    - name: git-url
+      value: '{{source_url}}'
+    - name: revision
+      value: '{{revision}}'
+    - name: output-image
+      value: quay.io/redhat-user-workloads/calunga-tenant/task-build-npm-package:on-pr-{{revision}}
+    - name: image-expires-after
+      value: 5d
+    - name: dockerfile
+      value: Dockerfile
+    - name: path-context
+      value: tasks/build-npm-package-oci-ta.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-task-build-npm-package
+  workspaces:
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'
+  pipelineRef:
+    name: bundle-build
+status: {}

--- a/.tekton/task-build-npm-package-push.yaml
+++ b/.tekton/task-build-npm-package-push.yaml
@@ -1,0 +1,38 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/calungaproject/plumbing?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && ( "tasks/build-npm-package-oci-ta.yaml".pathChanged() || ".tekton/task-build-npm-package-push.yaml".pathChanged() || ".tekton/bundle-build-pipeline.yaml".pathChanged() )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: calunga-v2
+    appstudio.openshift.io/component: task-build-npm-package
+    pipelines.appstudio.openshift.io/type: build
+  name: task-build-npm-package-on-push
+  namespace: calunga-tenant
+spec:
+  params:
+    - name: git-url
+      value: '{{source_url}}'
+    - name: revision
+      value: '{{revision}}'
+    - name: output-image
+      value: quay.io/redhat-user-workloads/calunga-tenant/task-build-npm-package:{{revision}}
+    - name: dockerfile
+      value: Dockerfile
+    - name: path-context
+      value: tasks/build-npm-package-oci-ta.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-task-build-npm-package
+  workspaces:
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'
+  pipelineRef:
+    name: bundle-build
+status: {}

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ The [npm-builder](./npm-builder) directory contains the factory image for npm Tr
 
 Published to Quay as `npm-builder` via Konflux component `npm-builder`.
 
+Tekton task `build-npm-package-oci-ta` is bundled as `task-build-npm-package` for the
+`npm-registry` onboarding pipeline.
+
 ## Utils Image
 
 The [utils](./utils) directory is the source for the calunga utils image. This image is used for

--- a/npm-builder/Containerfile
+++ b/npm-builder/Containerfile
@@ -51,7 +51,7 @@ RUN chmod +x /tmp/install-rust-toolset.sh && \
 
 RUN useradd -m -u 1001 -s /bin/bash builder
 
-COPY --chmod=755 scripts/build-npm-package scripts/collect-npm-artifacts /usr/local/bin/
+COPY --chmod=755 scripts/build-npm-package scripts/collect-npm-artifacts scripts/npm-publish-pulp /usr/local/bin/
 
 # rust-toolset + llvm-toolset (dependency) install under /opt/rh/* — same as `scl enable`.
 ENV PATH="/opt/rh/rust-toolset/root/usr/bin:/opt/rh/llvm-toolset/root/usr/bin:/usr/local/bin:${PATH}"

--- a/npm-builder/README.md
+++ b/npm-builder/README.md
@@ -65,10 +65,11 @@ quay.io/redhat-user-workloads/calunga-tenant/npm-builder:<tag>
 | Script | Role |
 | ------ | ---- |
 | `build-npm-package` | Run entrypoint + smoke for one manifest |
-| `collect-npm-artifacts` | Stage `out/*.tgz` for OCI / publish steps |
+| `collect-npm-artifacts` | Stage `out/*.tgz` for OCI push / optional Pulp publish |
+| `npm-publish-pulp` | Optional Pulp npm publish (deferred; Tekton step only) |
 | `build_scripts/install-rust-toolset.sh` | Install + versionlock pinned rust-toolset RPMs |
 
-Publishing to Pulp and cosign are handled in **Tekton steps**, not in these scripts.
+Publishing to Quay (OCI artifact), optional Pulp, and cosign are handled in **Tekton steps**, not in these scripts.
 
 ## Local build
 

--- a/npm-builder/scripts/npm-publish-pulp
+++ b/npm-builder/scripts/npm-publish-pulp
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Publish factory .tgz outputs to a Pulp npm repository.
+# Credentials come from env or a mounted npmrc — never from recipe scripts.
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: npm-publish-pulp <artifact-dir>
+
+Environment:
+  PULP_NPM_REGISTRY_URL   npm registry URL (required), e.g.
+                            https://pulp.example.com/pulp/content/npm/calunga-stage/
+  NPM_PUBLISH_NPMRC       Full .npmrc contents (preferred when secret provides npmrc key)
+  NPM_PUBLISH_USERNAME    Basic auth username (with NPM_PUBLISH_PASSWORD)
+  NPM_PUBLISH_PASSWORD    Basic auth password
+  NPM_CONFIG_USERCONFIG   Override npmrc path (default: /tmp/npm-publish.npmrc)
+EOF
+}
+
+ARTIFACT_DIR="${1:-}"
+if [[ -z "${ARTIFACT_DIR}" || "${ARTIFACT_DIR}" == "-h" || "${ARTIFACT_DIR}" == "--help" ]]; then
+    usage
+    exit 2
+fi
+
+REGISTRY_URL="${PULP_NPM_REGISTRY_URL:?PULP_NPM_REGISTRY_URL is required}"
+NPMRC="${NPM_CONFIG_USERCONFIG:-/tmp/npm-publish.npmrc}"
+
+write_npmrc() {
+    if [[ -n "${NPM_PUBLISH_NPMRC:-}" ]]; then
+        printf '%s\n' "${NPM_PUBLISH_NPMRC}" > "${NPMRC}"
+        return
+    fi
+
+    if [[ -n "${NPM_PUBLISH_USERNAME:-}" && -n "${NPM_PUBLISH_PASSWORD:-}" ]]; then
+        local host
+        host="$(python3 - <<'PY'
+import os
+from urllib.parse import urlparse
+print(urlparse(os.environ["PULP_NPM_REGISTRY_URL"]).netloc)
+PY
+)"
+        local token
+        token="$(printf '%s:%s' "${NPM_PUBLISH_USERNAME}" "${NPM_PUBLISH_PASSWORD}" | base64 | tr -d '\n')"
+        cat > "${NPMRC}" <<EOF
+registry=${REGISTRY_URL}
+//${host}/:_auth=${token}
+always-auth=true
+EOF
+        return
+    fi
+
+    echo "npm publish credentials required (NPM_PUBLISH_NPMRC or username/password)" >&2
+    exit 1
+}
+
+write_npmrc
+chmod 600 "${NPMRC}"
+export NPM_CONFIG_USERCONFIG="${NPMRC}"
+
+shopt -s nullglob globstar
+mapfile -t tarballs < <(find "${ARTIFACT_DIR}" -type f -name '*.tgz' | sort)
+if [[ ${#tarballs[@]} -eq 0 ]]; then
+    echo "No .tgz files under ${ARTIFACT_DIR}" >&2
+    exit 1
+fi
+
+published=()
+failed=()
+
+for tgz in "${tarballs[@]}"; do
+    echo "Publishing ${tgz} to ${REGISTRY_URL}"
+    if npm publish "${tgz}" --registry "${REGISTRY_URL}"; then
+        published+=("${tgz}")
+    else
+        failed+=("${tgz}")
+    fi
+done
+
+echo ""
+echo "Published (${#published[@]}):"
+printf '  - %s\n' "${published[@]}"
+if [[ ${#failed[@]} -gt 0 ]]; then
+    echo "Failed (${#failed[@]}):"
+    printf '  - %s\n' "${failed[@]}"
+    exit 1
+fi

--- a/tasks/build-npm-package-oci-ta.yaml
+++ b/tasks/build-npm-package-oci-ta.yaml
@@ -1,0 +1,263 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: build-npm-package-oci-ta
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: npm, konflux, trusted-libraries
+  labels:
+    app.kubernetes.io/version: "0.1"
+spec:
+  description: >-
+    Build npm Trusted Libraries packages from onboarding recipes and push
+    collected tarballs as an OCI artifact to Quay (mirrors build-python-wheels).
+    Optional Pulp Stage publish when PUBLISH_TO_PULP=true.
+  params:
+    - name: PACKAGES
+      description: >-
+        Package directories to build, e.g. ["packages/esbuild/0.28.0"]
+      type: array
+    - name: SOURCE_ARTIFACT
+      description: Trusted Artifact URI with the onboarding repo checkout
+      type: string
+    - name: BUILDER_IMAGE
+      description: Pinned npm-builder image reference
+      type: string
+    - name: IMAGE
+      description: Reference of the npm packages OCI artifact to produce
+      type: string
+    - name: IMAGE_EXPIRES_AFTER
+      description: >-
+        Delete image tag after specified time. Empty means keep the tag.
+        Examples: 1h, 2d, 5d, 3w.
+      type: string
+      default: ""
+    - name: PULP_NPM_REGISTRY_URL
+      description: Pulp npm registry URL for stage publish
+      type: string
+      default: ""
+    - name: NPM_PUBLISH_SECRET_NAME
+      description: K8s secret with npm publish credentials (username/password or npmrc)
+      type: string
+      default: rhtl-pulp-npm-stage-credentials
+    - name: PUBLISH_TO_PULP
+      description: When true, npm publish to Pulp Stage (requires stage secret)
+      type: string
+      default: "false"
+    - name: caTrustConfigMapKey
+      type: string
+      default: ca-bundle.crt
+    - name: caTrustConfigMapName
+      type: string
+      default: trusted-ca
+  results:
+    - name: PACKAGES_BUILT
+      description: Comma-separated list of package directories built
+    - name: IMAGE_DIGEST
+      description: Digest of the OCI artifact just pushed
+    - name: IMAGE_URL
+      description: OCI artifact repository and tag
+    - name: IMAGE_REF
+      description: OCI artifact reference (image@digest)
+  volumes:
+    - name: trusted-ca
+      configMap:
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        name: $(params.caTrustConfigMapName)
+        optional: true
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+  steps:
+    - name: use-trusted-artifact
+      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:2712c8a6453fc9db5fc4c2d9d952554a4eea46d2fdba47a272b79fa07f8c8c40
+      args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+      volumeMounts:
+        - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+          name: trusted-ca
+          readOnly: true
+          subPath: ca-bundle.crt
+    - name: build-packages
+      image: $(params.BUILDER_IMAGE)
+      workingDir: /var/workdir/source
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        cd /var/workdir/source
+        mkdir -p /var/workdir/built
+        : > /var/workdir/built/list.txt
+        PACKAGES=(
+          $(params.PACKAGES[*])
+        )
+        for pkg in "${PACKAGES[@]}"; do
+          manifest="${pkg}/manifest.json"
+          if [[ ! -f "${manifest}" ]]; then
+            echo "Missing manifest: ${manifest}" >&2
+            exit 1
+          fi
+          echo "[build-packages] ${pkg}"
+          build-npm-package --manifest "${manifest}"
+          echo "${pkg}" >> /var/workdir/built/list.txt
+        done
+      computeResources:
+        limits:
+          cpu: "4"
+          memory: 8Gi
+        requests:
+          cpu: "2"
+          memory: 4Gi
+    - name: collect-artifacts
+      image: $(params.BUILDER_IMAGE)
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        rm -rf /var/workdir/artifact
+        mkdir -p /var/workdir/artifact
+        while IFS= read -r pkg; do
+          [[ -n "${pkg}" ]] || continue
+          out="/var/workdir/source/${pkg}/out"
+          if [[ ! -d "${out}" ]]; then
+            echo "Missing out/ for ${pkg}" >&2
+            exit 1
+          fi
+          collect-npm-artifacts "${out}" "/var/workdir/artifact"
+        done < /var/workdir/built/list.txt
+      computeResources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "1"
+          memory: 512Mi
+    - name: embed-compliance
+      image: $(params.BUILDER_IMAGE)
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        # Phase 1 stub: compliance metadata is computed in a later iteration.
+        echo "[embed-compliance] stub — tl-compliance.json / artifact.json not embedded yet"
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          cpu: "100m"
+          memory: 256Mi
+    - name: create-oci-artifact
+      image: quay.io/konflux-ci/oras:latest@sha256:1beeecce012c99794568f74265c065839f9703d28306a8430b667f639343a98b
+      workingDir: /var/workdir
+      volumeMounts:
+        - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+          name: trusted-ca
+          readOnly: true
+          subPath: ca-bundle.crt
+      env:
+        - name: IMAGE
+          value: $(params.IMAGE)
+        - name: IMAGE_EXPIRES_AFTER
+          value: $(params.IMAGE_EXPIRES_AFTER)
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        echo "[$(date --utc -Ins)] Pushing npm packages OCI artifact"
+
+        select-oci-auth "$IMAGE" > auth.json
+        AUTHFILE="$(realpath auth.json)"
+
+        EXPIRE_LABEL=()
+        [ -n "$IMAGE_EXPIRES_AFTER" ] && EXPIRE_LABEL=("--annotation" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
+
+        cd artifact
+
+        echo "Pushing OCI artifact to ${IMAGE}"
+        if ! retry oras push "$IMAGE" \
+          --registry-config "${AUTHFILE}" \
+          "${EXPIRE_LABEL[@]}" \
+          --artifact-type "application/vnd.npm.packages" \
+          *
+        then
+          echo "Failed to push OCI artifact ${IMAGE} to registry"
+          exit 1
+        fi
+
+        if ! RESULTING_DIGEST=$(retry oras resolve \
+          --registry-config "${AUTHFILE}" "${IMAGE}")
+        then
+          echo "Failed to get digest for ${IMAGE} from registry"
+          exit 1
+        fi
+
+        echo -n "$IMAGE" | tee "$(results.IMAGE_URL.path)"
+        echo -n "$RESULTING_DIGEST" | tee "$(results.IMAGE_DIGEST.path)"
+        echo -n "${IMAGE}@${RESULTING_DIGEST}" | tee "$(results.IMAGE_REF.path)"
+
+        echo "[$(date --utc -Ins)] End create-oci-artifact"
+      computeResources:
+        limits:
+          memory: 1Gi
+        requests:
+          cpu: "1"
+          memory: 1Gi
+    - name: publish-pulp-stage
+      image: $(params.BUILDER_IMAGE)
+      env:
+        - name: PULP_NPM_REGISTRY_URL
+          value: $(params.PULP_NPM_REGISTRY_URL)
+        - name: PUBLISH_TO_PULP
+          value: $(params.PUBLISH_TO_PULP)
+        - name: NPM_PUBLISH_NPMRC
+          valueFrom:
+            secretKeyRef:
+              name: $(params.NPM_PUBLISH_SECRET_NAME)
+              key: npmrc
+              optional: true
+        - name: NPM_PUBLISH_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: $(params.NPM_PUBLISH_SECRET_NAME)
+              key: username
+              optional: true
+        - name: NPM_PUBLISH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: $(params.NPM_PUBLISH_SECRET_NAME)
+              key: password
+              optional: true
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        if [[ "${PUBLISH_TO_PULP}" != "true" ]]; then
+          echo "[publish-pulp-stage] skipped (PUBLISH_TO_PULP=${PUBLISH_TO_PULP})"
+          exit 0
+        fi
+        if [[ -z "${PULP_NPM_REGISTRY_URL}" ]]; then
+          echo "PULP_NPM_REGISTRY_URL is required when PUBLISH_TO_PULP=true" >&2
+          exit 1
+        fi
+        npm-publish-pulp /var/workdir/artifact
+      computeResources:
+        limits:
+          memory: 1Gi
+        requests:
+          cpu: "500m"
+          memory: 512Mi
+    - name: record-results
+      image: $(params.BUILDER_IMAGE)
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        list="$(tr '\n' ',' < /var/workdir/built/list.txt | sed 's/,$//')"
+        echo -n "${list}" | tee "$(results.PACKAGES_BUILT.path)"
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          cpu: "100m"
+          memory: 128Mi


### PR DESCRIPTION
## Summary by Sourcery

Introduce a Tekton task and CI pipelines for building and publishing npm package OCI artifacts, integrating with the npm-registry onboarding flow.

New Features:
- Add npm build Tekton task build-npm-package-oci-ta to build trusted npm packages, push them as OCI artifacts, and optionally publish to Pulp.
- Add on-pull-request and on-push Tekton PipelineRun definitions to build and bundle the build-npm-package task image.
- Introduce an npm-publish-pulp helper script in the npm-builder image for optional Pulp npm publication.

Enhancements:
- Clarify documentation around the npm-builder image, its artifacts, and its consumption by the npm-registry onboarding repository.

Documentation:
- Document the new build-npm-package-oci-ta Tekton task usage and its role in the npm-registry onboarding pipeline within project READMEs.