### PR TITLE
Add bundle PipelineRuns for sast-snyk-check-sdist task

### DIFF
--- a/.tekton/task-sast-snyk-check-sdist-pull-request.yaml
+++ b/.tekton/task-sast-snyk-check-sdist-pull-request.yaml
@@ -1,0 +1,41 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/calungaproject/plumbing?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && ( "tasks/sast-snyk-check-sdist.yaml".pathChanged() || ".tekton/task-sast-snyk-check-sdist-pull-request.yaml".pathChanged() || ".tekton/bundle-build-pipeline.yaml".pathChanged() )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: calunga-v2
+    appstudio.openshift.io/component: task-sast-snyk-check-sdist
+    pipelines.appstudio.openshift.io/type: build
+  name: task-sast-snyk-check-sdist-on-pull-request
+  namespace: calunga-tenant
+spec:
+  params:
+    - name: git-url
+      value: '{{source_url}}'
+    - name: revision
+      value: '{{revision}}'
+    - name: output-image
+      value: quay.io/redhat-user-workloads/calunga-tenant/task-sast-snyk-check-sdist:on-pr-{{revision}}
+    - name: image-expires-after
+      value: 5d
+    - name: dockerfile
+      value: Dockerfile
+    - name: path-context
+      value: tasks/sast-snyk-check-sdist.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-task-sast-snyk-check-sdist
+  workspaces:
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'
+  pipelineRef:
+    name: bundle-build
+status: {}

--- a/.tekton/task-sast-snyk-check-sdist-push.yaml
+++ b/.tekton/task-sast-snyk-check-sdist-push.yaml
@@ -1,0 +1,38 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/calungaproject/plumbing?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && ( "tasks/sast-snyk-check-sdist.yaml".pathChanged() || ".tekton/task-sast-snyk-check-sdist-push.yaml".pathChanged() || ".tekton/bundle-build-pipeline.yaml".pathChanged() )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: calunga-v2
+    appstudio.openshift.io/component: task-sast-snyk-check-sdist
+    pipelines.appstudio.openshift.io/type: build
+  name: task-sast-snyk-check-sdist-on-push
+  namespace: calunga-tenant
+spec:
+  params:
+    - name: git-url
+      value: '{{source_url}}'
+    - name: revision
+      value: '{{revision}}'
+    - name: output-image
+      value: quay.io/redhat-user-workloads/calunga-tenant/task-sast-snyk-check-sdist:{{revision}}
+    - name: dockerfile
+      value: Dockerfile
+    - name: path-context
+      value: tasks/sast-snyk-check-sdist.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-task-sast-snyk-check-sdist
+  workspaces:
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'
+  pipelineRef:
+    name: bundle-build
+status: {}


### PR DESCRIPTION
Add push and pull-request PipelineRuns to build the sast-snyk-check-sdist task as an OCI bundle, matching the existing pattern for build-python-wheels.

## Summary by Sourcery

Add Tekton PipelineRuns to build the sast-snyk-check-sdist task as an OCI bundle on pull requests and pushes to main.

CI:
- Introduce pull-request PipelineRun for building the sast-snyk-check-sdist task bundle when relevant files change.
- Introduce push PipelineRun for building the sast-snyk-check-sdist task bundle on main when relevant files change.