### PR TITLE
Updated npm build-packages to use command + args

### DIFF
--- a/npm-builder/Containerfile
+++ b/npm-builder/Containerfile
@@ -51,7 +51,7 @@ RUN chmod +x /tmp/install-rust-toolset.sh && \
 
 RUN useradd -m -u 1001 -s /bin/bash builder
 
-COPY --chmod=755 scripts/build-npm-package scripts/collect-npm-artifacts scripts/npm-publish-pulp /usr/local/bin/
+COPY --chmod=755 scripts/build-npm-package scripts/build-npm-packages scripts/collect-npm-artifacts scripts/npm-publish-pulp /usr/local/bin/
 
 # rust-toolset + llvm-toolset (dependency) install under /opt/rh/* — same as `scl enable`.
 ENV PATH="/opt/rh/rust-toolset/root/usr/bin:/opt/rh/llvm-toolset/root/usr/bin:/usr/local/bin:${PATH}"

--- a/npm-builder/README.md
+++ b/npm-builder/README.md
@@ -65,6 +65,7 @@ quay.io/redhat-user-workloads/calunga-tenant/npm-builder:<tag>
 | Script | Role |
 | ------ | ---- |
 | `build-npm-package` | Run entrypoint + smoke for one manifest |
+| `build-npm-packages` | Build multiple package dirs (Tekton `PACKAGES` args) |
 | `collect-npm-artifacts` | Stage `out/*.tgz` for OCI push / optional Pulp publish |
 | `npm-publish-pulp` | Optional Pulp npm publish (deferred; Tekton step only) |
 | `build_scripts/install-rust-toolset.sh` | Install + versionlock pinned rust-toolset RPMs |

--- a/npm-builder/scripts/build-npm-packages
+++ b/npm-builder/scripts/build-npm-packages
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Build one or more npm TL package recipes. Each argument is a package directory
+# under the repo root (e.g. packages/esbuild/0.28.0). Invoked from Tekton with
+# args expanded from the PACKAGES array param.
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: build-npm-packages <pkg-dir> [<pkg-dir>...]
+
+Build onboarder recipes via build-npm-package. Writes package dirs, one per line,
+to BUILT_LIST (default: /var/workdir/built/list.txt).
+EOF
+}
+
+BUILT_LIST="${BUILT_LIST:-/var/workdir/built/list.txt}"
+
+if [[ $# -lt 1 ]]; then
+    usage >&2
+    exit 2
+fi
+
+mkdir -p "$(dirname "${BUILT_LIST}")"
+: > "${BUILT_LIST}"
+
+for pkg in "$@"; do
+    manifest="${pkg}/manifest.json"
+    if [[ ! -f "${manifest}" ]]; then
+        echo "Missing manifest: ${manifest}" >&2
+        exit 1
+    fi
+    echo "[build-npm-packages] ${pkg}"
+    build-npm-package --manifest "${manifest}"
+    echo "${pkg}" >> "${BUILT_LIST}"
+done
+
+echo "[build-npm-packages] Done"

--- a/tasks/build-npm-package-oci-ta.yaml
+++ b/tasks/build-npm-package-oci-ta.yaml
@@ -88,25 +88,10 @@ spec:
     - name: build-packages
       image: $(params.BUILDER_IMAGE)
       workingDir: /var/workdir/source
-      script: |
-        #!/usr/bin/env bash
-        set -euo pipefail
-        cd /var/workdir/source
-        mkdir -p /var/workdir/built
-        : > /var/workdir/built/list.txt
-        PACKAGES=(
-          $(params.PACKAGES[*])
-        )
-        for pkg in "${PACKAGES[@]}"; do
-          manifest="${pkg}/manifest.json"
-          if [[ ! -f "${manifest}" ]]; then
-            echo "Missing manifest: ${manifest}" >&2
-            exit 1
-          fi
-          echo "[build-packages] ${pkg}"
-          build-npm-package --manifest "${manifest}"
-          echo "${pkg}" >> /var/workdir/built/list.txt
-        done
+      command:
+        - build-npm-packages
+      args:
+        - $(params.PACKAGES[*])
       computeResources:
         limits:
           cpu: "4"


### PR DESCRIPTION
Implements CALUNGA-292

Assisted by Cursor v3.5.33

## Summary by Sourcery

Build:
- Update the build-npm-package Tekton task to pass package paths as container arguments and iterate over them in the build step.