### PR TITLE
Fix oras absolute path

### DIFF
--- a/tasks/sast-snyk-check-sdist.yaml
+++ b/tasks/sast-snyk-check-sdist.yaml
@@ -305,9 +305,10 @@ spec:
         select-oci-auth "${IMAGE}" > "${AUTHFILE}"
 
         echo "Uploading SARIF results to ${IMAGE}..."
+        cd /var/workdir
         if ! retry oras attach --registry-config "${AUTHFILE}" \
             --artifact-type "application/sarif+json" \
-            "${IMAGE}" "${MERGED_SARIF}:application/sarif+json" 2>&1; then
+            "${IMAGE}" "snyk-sdist-results.sarif:application/sarif+json" 2>&1; then
             echo "WARNING: Failed to upload SARIF results (non-fatal)"
         else
             echo "SARIF results uploaded successfully"

--- a/tasks/sast-snyk-check-sdist.yaml
+++ b/tasks/sast-snyk-check-sdist.yaml
@@ -305,10 +305,10 @@ spec:
         select-oci-auth "${IMAGE}" > "${AUTHFILE}"
 
         echo "Uploading SARIF results to ${IMAGE}..."
-        cd /var/workdir
+        cd "$(dirname "${MERGED_SARIF}")"
         if ! retry oras attach --registry-config "${AUTHFILE}" \
             --artifact-type "application/sarif+json" \
-            "${IMAGE}" "snyk-sdist-results.sarif:application/sarif+json" 2>&1; then
+            "${IMAGE}" "$(basename "${MERGED_SARIF}"):application/sarif+json" 2>&1; then
             echo "WARNING: Failed to upload SARIF results (non-fatal)"
         else
             echo "SARIF results uploaded successfully"

--- a/tasks/sast-snyk-check-sdist.yaml
+++ b/tasks/sast-snyk-check-sdist.yaml
@@ -96,7 +96,7 @@ spec:
         ls -la "${ARTIFACT_DIR}"
 
     - name: extract-sdists
-      image: quay.io/konflux-ci/konflux-test:v1.5.0@sha256:fbd5ad045b902065990218922aa6f343e8eb5fd039ecd445bc54819b8e968c3e
+      image: quay.io/konflux-ci/konflux-test:v1.5.2@sha256:c370a7bc6e172cdbab001f1a19f37ebc95f47c3d8fe2d915fa4641132490ead7
       script: |
         #!/bin/bash
         set -euo pipefail
@@ -121,7 +121,7 @@ spec:
         echo "Extracted ${SDIST_COUNT} sdist(s)"
 
     - name: sast-snyk-check
-      image: quay.io/konflux-ci/konflux-test:v1.5.0@sha256:fbd5ad045b902065990218922aa6f343e8eb5fd039ecd445bc54819b8e968c3e
+      image: quay.io/konflux-ci/konflux-test:v1.5.2@sha256:c370a7bc6e172cdbab001f1a19f37ebc95f47c3d8fe2d915fa4641132490ead7
       volumeMounts:
         - mountPath: /etc/secrets
           name: snyk-secret


### PR DESCRIPTION
## Summary by Sourcery

Update SAST Snyk sdist task to use a newer konflux-test image and correct ORAS upload behavior for SARIF results.

Enhancements:
- Adjust SARIF upload step to run from the work directory and attach a fixed SARIF filename instead of a variable path.

Build:
- Bump konflux-test container image from v1.5.0 to v1.5.2 for extract-sdists and sast-snyk-check steps.