### PR TITLE
test: add SBOM operation test coverage to build-wheels test suite

### DIFF
--- a/tests/test-build-wheels.sh
+++ b/tests/test-build-wheels.sh
@@ -132,6 +132,43 @@ assert_file_exists() {
     fi
 }
 
+assert_wheel_contains() {
+    local test_name="$1"
+    local wheel_path="$2"
+    local pattern="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if unzip -Z1 "$wheel_path" | grep -q "$pattern"; then
+        log_info "✓ $test_name: PASSED"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        log_error "✗ $test_name: FAILED (pattern '$pattern' not found in $wheel_path)"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+assert_wheel_not_contains() {
+    local test_name="$1"
+    local wheel_path="$2"
+    local pattern="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+
+    if unzip -Z1 "$wheel_path" | grep -q "$pattern"; then
+        log_error "✗ $test_name: FAILED (pattern '$pattern' unexpectedly found in $wheel_path)"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    else
+        log_info "✓ $test_name: PASSED"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    fi
+}
+
 # Setup function - build or pull container image
 setup() {
     log_info "Setting up test environment..."
@@ -309,6 +346,80 @@ test_build_sequence_summaries() {
     assert_contains "Summary for second package" "$output" "./build-sequence-summary-wheel__0.42.0.json"
 }
 
+test_sbom_cyclonedx_removal() {
+  log_info "Running test: CycloneDX SBOM removal from manylinux wheels"
+
+  local test_dir="$TEST_OUTPUT_DIR/sbom-cdx-removal"
+  local output
+
+  # Build a package with native C extensions to trigger auditwheel repair.
+  # auditwheel >= 6.5 injects CycloneDX SBOMs into repaired wheels;
+  # build-wheels then calls remove-cyclonedx-sboms to strip them.
+  set +e
+  output=$(run_build_wheels "$test_dir" "markupsafe==2.1.5" 2>&1)
+  local exit_code=$?
+  set -e
+
+  assert_success "Build completes successfully" "$exit_code"
+  assert_contains "CycloneDX removal ran" "$output" "Removing auditwheel-generated SBOMs from repaired manylinux wheels"
+
+  # Find the manylinux wheel (produced by auditwheel repair)
+  local whl
+  whl=$(find "$test_dir/output/wheels-repo/downloads" -iname 'markupsafe-*manylinux*.whl' | head -1)
+
+  if [ -z "$whl" ]; then
+    TESTS_RUN=$((TESTS_RUN + 1))
+    log_error "✗ MarkupSafe manylinux wheel not found on disk: FAILED"
+    log_error "  Wheels present: $(ls "$test_dir/output/wheels-repo/downloads/"*.whl 2>/dev/null || echo 'none')"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    return 1
+  fi
+
+  # Verify CycloneDX SBOMs were removed by remove-cyclonedx-sboms
+  assert_wheel_not_contains "No CycloneDX SBOMs in manylinux wheel" "$whl" '\.cdx\.json'
+
+  # Verify Fromager's SPDX SBOM was preserved and renamed
+  assert_wheel_not_contains "No fromager.spdx.json (should be renamed)" "$whl" 'fromager\.spdx\.json'
+  assert_wheel_contains "redhat.spdx.json present" "$whl" 'redhat\.spdx\.json'
+}
+
+test_sbom_integration() {
+  log_info "Running test: SBOM integration (end-to-end with container build)"
+
+  local test_dir="$TEST_OUTPUT_DIR/sbom-integration"
+  local output
+
+  set +e
+  output=$(run_build_wheels "$test_dir" "setuptools==69.0.0" 2>&1)
+  local exit_code=$?
+  set -e
+
+  assert_success "Build completes successfully" "$exit_code"
+
+  # Find the output wheel
+  local whl
+  whl=$(find "$test_dir/output/wheels-repo/downloads" -name 'setuptools-*-none-any.whl' | head -1)
+
+  if [ -z "$whl" ]; then
+    TESTS_RUN=$((TESTS_RUN + 1))
+    log_error "✗ Setuptools wheel not found on disk: FAILED"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    return 1
+  fi
+
+  # Verify SBOM was renamed from fromager.spdx.json to redhat.spdx.json
+  assert_wheel_not_contains "No fromager.spdx.json in output wheel" "$whl" 'fromager\.spdx\.json'
+  assert_wheel_contains "redhat.spdx.json present in output wheel" "$whl" 'redhat\.spdx\.json'
+
+  # Verify no CycloneDX SBOMs (setuptools is pure-python so auditwheel doesn't
+  # run, but verify the invariant anyway)
+  assert_wheel_not_contains "No CycloneDX SBOMs in output wheel" "$whl" '\.cdx\.json'
+
+  # Verify file_name= qualifier in PURL
+  local sbom_content
+  sbom_content=$(unzip -p "$whl" "$(unzip -Z1 "$whl" | grep 'redhat\.spdx\.json')")
+  assert_contains "PURL has file_name= qualifier" "$sbom_content" "file_name=$(basename "$whl")"
+}
 
 # Main execution
 main() {
@@ -354,6 +465,8 @@ main() {
     test_basic_functionality
     test_file_generation
     test_build_sequence_summaries
+    test_sbom_cyclonedx_removal
+    test_sbom_integration
     echo
     echo "======================================="
     echo "  Test Results"

--- a/tests/test-build-wheels.sh
+++ b/tests/test-build-wheels.sh
@@ -157,7 +157,6 @@ assert_wheel_not_contains() {
 
     TESTS_RUN=$((TESTS_RUN + 1))
 
-
     if unzip -Z1 "$wheel_path" | grep -q "$pattern"; then
         log_error "✗ $test_name: FAILED (pattern '$pattern' unexpectedly found in $wheel_path)"
         TESTS_FAILED=$((TESTS_FAILED + 1))
@@ -347,78 +346,91 @@ test_build_sequence_summaries() {
 }
 
 test_sbom_cyclonedx_removal() {
-  log_info "Running test: CycloneDX SBOM removal from manylinux wheels"
+    log_info "Running test: CycloneDX SBOM removal from manylinux wheels"
 
-  local test_dir="$TEST_OUTPUT_DIR/sbom-cdx-removal"
-  local output
+    local test_dir="$TEST_OUTPUT_DIR/sbom-cdx-removal"
+    local output
 
-  # Build a package with native C extensions to trigger auditwheel repair.
-  # auditwheel >= 6.5 injects CycloneDX SBOMs into repaired wheels;
-  # build-wheels then calls remove-cyclonedx-sboms to strip them.
-  set +e
-  output=$(run_build_wheels "$test_dir" "markupsafe==2.1.5" 2>&1)
-  local exit_code=$?
-  set -e
+    # Build a package with native C extensions to trigger auditwheel repair.
+    # auditwheel >= 6.5 injects CycloneDX SBOMs into repaired wheels;
+    # build-wheels then calls remove-cyclonedx-sboms to strip them.
+    set +e
+    output=$(run_build_wheels "$test_dir" "markupsafe==2.1.5" 2>&1)
+    local exit_code=$?
+    set -e
 
-  assert_success "Build completes successfully" "$exit_code"
-  assert_contains "CycloneDX removal ran" "$output" "Removing auditwheel-generated SBOMs from repaired manylinux wheels"
+    assert_success "Build completes successfully" "$exit_code"
+    assert_contains "CycloneDX removal ran" "$output" "Removing auditwheel-generated SBOMs from repaired manylinux wheels"
 
-  # Find the manylinux wheel (produced by auditwheel repair)
-  local whl
-  whl=$(find "$test_dir/output/wheels-repo/downloads" -iname 'markupsafe-*manylinux*.whl' | head -1)
+    # Find the manylinux wheel (produced by auditwheel repair)
+    local whl
+    whl=$(find "$test_dir/output/wheels-repo/downloads" -iname 'markupsafe-*manylinux*.whl' | head -1)
 
-  if [ -z "$whl" ]; then
-    TESTS_RUN=$((TESTS_RUN + 1))
-    log_error "✗ MarkupSafe manylinux wheel not found on disk: FAILED"
-    log_error "  Wheels present: $(ls "$test_dir/output/wheels-repo/downloads/"*.whl 2>/dev/null || echo 'none')"
-    TESTS_FAILED=$((TESTS_FAILED + 1))
-    return 1
-  fi
+    if [ -z "$whl" ]; then
+        TESTS_RUN=$((TESTS_RUN + 1))
+        log_error "✗ MarkupSafe manylinux wheel not found on disk: FAILED"
+        log_error "  Wheels present: $(ls "$test_dir/output/wheels-repo/downloads/"*.whl 2>/dev/null || echo 'none')"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
 
-  # Verify CycloneDX SBOMs were removed by remove-cyclonedx-sboms
-  assert_wheel_not_contains "No CycloneDX SBOMs in manylinux wheel" "$whl" '\.cdx\.json'
+    # Verify CycloneDX SBOMs were removed by remove-cyclonedx-sboms
+    assert_wheel_not_contains "No CycloneDX SBOMs in manylinux wheel" "$whl" '\.cdx\.json'
 
-  # Verify Fromager's SPDX SBOM was preserved and renamed
-  assert_wheel_not_contains "No fromager.spdx.json (should be renamed)" "$whl" 'fromager\.spdx\.json'
-  assert_wheel_contains "redhat.spdx.json present" "$whl" 'redhat\.spdx\.json'
+    # Verify Fromager's SPDX SBOM was preserved and renamed
+    assert_wheel_not_contains "No fromager.spdx.json (should be renamed)" "$whl" 'fromager\.spdx\.json'
+    assert_wheel_contains "redhat.spdx.json present" "$whl" 'redhat\.spdx\.json'
 }
 
 test_sbom_integration() {
-  log_info "Running test: SBOM integration (end-to-end with container build)"
+    log_info "Running test: SBOM integration (end-to-end with container build)"
 
-  local test_dir="$TEST_OUTPUT_DIR/sbom-integration"
-  local output
+    local test_dir="$TEST_OUTPUT_DIR/sbom-integration"
+    local output
 
-  set +e
-  output=$(run_build_wheels "$test_dir" "setuptools==69.0.0" 2>&1)
-  local exit_code=$?
-  set -e
+    set +e
+    output=$(run_build_wheels "$test_dir" "setuptools==69.0.0" 2>&1)
+    local exit_code=$?
+    set -e
 
-  assert_success "Build completes successfully" "$exit_code"
+    assert_success "Build completes successfully" "$exit_code"
 
-  # Find the output wheel
-  local whl
-  whl=$(find "$test_dir/output/wheels-repo/downloads" -name 'setuptools-*-none-any.whl' | head -1)
+    # Find the output wheel
+    local whl
+    whl=$(find "$test_dir/output/wheels-repo/downloads" -name 'setuptools-*-none-any.whl' | head -1)
 
-  if [ -z "$whl" ]; then
-    TESTS_RUN=$((TESTS_RUN + 1))
-    log_error "✗ Setuptools wheel not found on disk: FAILED"
-    TESTS_FAILED=$((TESTS_FAILED + 1))
-    return 1
-  fi
+    if [ -z "$whl" ]; then
+        TESTS_RUN=$((TESTS_RUN + 1))
+        log_error "✗ Setuptools wheel not found on disk: FAILED"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
 
-  # Verify SBOM was renamed from fromager.spdx.json to redhat.spdx.json
-  assert_wheel_not_contains "No fromager.spdx.json in output wheel" "$whl" 'fromager\.spdx\.json'
-  assert_wheel_contains "redhat.spdx.json present in output wheel" "$whl" 'redhat\.spdx\.json'
+    # Verify SBOM was renamed from fromager.spdx.json to redhat.spdx.json
+    assert_wheel_not_contains "No fromager.spdx.json in output wheel" "$whl" 'fromager\.spdx\.json'
+    assert_wheel_contains "redhat.spdx.json present in output wheel" "$whl" 'redhat\.spdx\.json'
 
-  # Verify no CycloneDX SBOMs (setuptools is pure-python so auditwheel doesn't
-  # run, but verify the invariant anyway)
-  assert_wheel_not_contains "No CycloneDX SBOMs in output wheel" "$whl" '\.cdx\.json'
+    # Verify no CycloneDX SBOMs (setuptools is pure-python so auditwheel doesn't
+    # run, but verify the invariant anyway)
+    assert_wheel_not_contains "No CycloneDX SBOMs in output wheel" "$whl" '\.cdx\.json'
 
-  # Verify file_name= qualifier in PURL
-  local sbom_content
-  sbom_content=$(unzip -p "$whl" "$(unzip -Z1 "$whl" | grep 'redhat\.spdx\.json')")
-  assert_contains "PURL has file_name= qualifier" "$sbom_content" "file_name=$(basename "$whl")"
+    # Verify file_name= qualifier in PURL
+    local sbom_content
+    sbom_content=$(unzip -p "$whl" "$(unzip -Z1 "$whl" | grep 'redhat\.spdx\.json')")
+
+    # Extract PURLs
+    local sbom_purls
+    sbom_purls=$(jq '.packages[].externalRefs[] | select(.referenceType == "purl") | .referenceLocator' <<< "$sbom_content")
+
+    assert_contains "PURL has file_name= qualifier" "$sbom_purls" "file_name=$(basename "$whl")"
+
+    # Verify creationInfo.creators
+    # Value comes from Fromager's overrides/settings.yaml
+    local creator_organization
+    creator_organization=$(jq '.creationInfo.creators[] | select(contains("Organization"))' <<< "$sbom_content")
+
+    # Should have Organization: Red Hat
+    assert_contains "Creator Organization is Red Hat" "$creator_organization" "Organization: Red Hat"
 }
 
 # Main execution

--- a/tests/test-build-wheels.sh
+++ b/tests/test-build-wheels.sh
@@ -132,6 +132,24 @@ assert_file_exists() {
     fi
 }
 
+assert_equals() {
+    local test_name="$1"
+    local expected="$2"
+    local actual="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if [ "$expected" = "$actual" ]; then
+        log_info "✓ $test_name: PASSED"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        log_error "✗ $test_name: FAILED (expected '$expected', got '$actual')"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
 assert_wheel_contains() {
     local test_name="$1"
     local wheel_path="$2"
@@ -433,6 +451,76 @@ test_sbom_integration() {
     assert_contains "Creator Organization is Red Hat" "$creator_organization" "Organization: Red Hat"
 }
 
+test_sbom_record_integrity() {
+    log_info "Running test: SBOM RECORD file integrity after patch-sbom-purl"
+
+    local test_dir="$TEST_OUTPUT_DIR/sbom-record"
+    local output
+
+    set +e
+    output=$(run_build_wheels "$test_dir" "setuptools==69.0.0" 2>&1)
+    local exit_code=$?
+    set -e
+
+    assert_success "Build completes successfully" "$exit_code"
+
+    # Find the output wheel
+    local whl
+    whl=$(find "$test_dir/output/wheels-repo/downloads" -name 'setuptools-*-none-any.whl' | head -1)
+
+    if [ -z "$whl" ]; then
+        TESTS_RUN=$((TESTS_RUN + 1))
+        log_error "✗ Setuptools wheel not found on disk: FAILED"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+
+    # Extract RECORD and SBOM to a temp directory
+    local tmpdir
+    tmpdir=$(mktemp -d)
+
+    local record_path
+    record_path=$(unzip -Z1 "$whl" | grep '\.dist-info/RECORD$')
+    local sbom_path
+    sbom_path=$(unzip -Z1 "$whl" | grep 'redhat\.spdx\.json')
+
+    if [ -z "$record_path" ] || [ -z "$sbom_path" ]; then
+        TESTS_RUN=$((TESTS_RUN + 1))
+        log_error "✗ RECORD or redhat.spdx.json not found in wheel: FAILED"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        rm -rf "$tmpdir"
+        return 1
+    fi
+
+    unzip -o "$whl" "$record_path" "$sbom_path" -d "$tmpdir"
+
+    # Parse the SBOM entry from RECORD
+    # Format: <path>,sha256=<urlsafe_b64_no_padding>,<size>
+    local record_line
+    record_line=$(grep 'redhat\.spdx\.json' "$tmpdir/$record_path")
+    local record_hash
+    record_hash=$(echo "$record_line" | cut -d',' -f2 | sed 's/^sha256=//')
+    local record_size
+    record_size=$(echo "$record_line" | cut -d',' -f3)
+
+    # Compute actual hash, match what is done in patch-sbom-purl
+    # - compute SHA-256 hash of the SBOM file
+    # - grab the hex hash (e.g. a1b2c3d4e5f6...)
+    # - convert hex text back to binary bytes (Python's hashlib.sha256().digest() returns raw bytes, not hex)
+    # - base64 encode raw bytes
+    # - swap characters so encoding is URL safe (match Python's base64.urlsafe_b64encode())
+    # - strip padding '=' characters from the end
+    local actual_hash
+    actual_hash=$(sha256sum "$tmpdir/$sbom_path" | cut -d' ' -f1 | xxd -r -p | base64 | tr '+/' '-_' | tr -d '=')
+    local actual_size
+    actual_size=$(wc -c < "$tmpdir/$sbom_path" | tr -d ' ')
+
+    assert_equals "RECORD hash matches actual SBOM sha256" "$record_hash" "$actual_hash"
+    assert_equals "RECORD size matches actual SBOM file size" "$record_size" "$actual_size"
+
+    rm -rf "$tmpdir"
+}
+
 # Main execution
 main() {
     # Parse command line arguments
@@ -479,6 +567,7 @@ main() {
     test_build_sequence_summaries
     test_sbom_cyclonedx_removal
     test_sbom_integration
+    test_sbom_record_integrity
     echo
     echo "======================================="
     echo "  Test Results"


### PR DESCRIPTION
Add tests for SBOM operations in build-wheels that had no coverage: 
-  CycloneDX SBOM removal from manylinux wheels
-  Fromager SPDX SBOM patching via patch-sbom-purl
-  RECORD file integrity after patching

Three new test functions:

- **test_sbom_cyclonedx_removal**: builds MarkupSafe (C extension) to trigger auditwheel repair, verifies CycloneDX removal code path ran via log message, confirms `.cdx.json` files are removed and Fromager SPDX SBOM renamed to `redhat.spdx.json`

- **test_sbom_integration**: end-to-end build of setuptools verifying SBOM rename, no CycloneDX artifacts, PURL `file_name=` qualifier matches URL-encoded wheel filename, and `creationInfo.creators` contains Red Hat organization

- **test_sbom_record_integrity**: verifies RECORD file hash (sha256, urlsafe-base64) and size for `redhat.spdx.json` match actual file after `patch-sbom-purl` modifies the SBOM

Supporting helpers: `assert_wheel_contains`, `assert_wheel_not_contains`, `assert_equals`.

Jira: CALUNGA-303

## Summary by Sourcery

Extend build-wheels test coverage for SBOM handling in manylinux and pure-Python wheels.

Tests:
- Add helper assertions to verify presence or absence of files within built wheel archives.
- Add a test that builds a manylinux MarkupSafe wheel to validate CycloneDX SBOM removal and Fromager SPDX SBOM renaming.
- Add an end-to-end setuptools build test to validate SBOM renaming, absence of CycloneDX artifacts, and correct PURL file_name qualifier in the embedded SBOM.