### PR TITLE
Update UBI8 base image to latest (8.10, 2026-06-17)

### DIFF
--- a/builder/Containerfile
+++ b/builder/Containerfile
@@ -1,5 +1,5 @@
 # default to latest supported policy, x86_64
-ARG BASEIMAGE=registry.access.redhat.com/ubi8/ubi@sha256:28a85f76ad1ea0a46a81a934b02fff48d75541f77777be403d48b6bb99a363ad
+ARG BASEIMAGE=registry.access.redhat.com/ubi8/ubi@sha256:8e573e1d76ff27f9e1219b33c114e48b0f7b86f2e6858cd8861e84431c7416e4
 ARG POLICY=manylinux_2_28
 ARG PLATFORM=x86_64
 ARG DEVTOOLSET_ROOTPATH=/opt/rh/gcc-toolset-14/root


### PR DESCRIPTION
Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Build:
- Switch the builder base image reference to the latest UBI8 (8.10) digest for default builds.