### PR TITLE
Add multi-arch builder pipeline for amd64 + arm64 support

### DIFF
--- a/.tekton/build-multiarch-pipeline.yaml
+++ b/.tekton/build-multiarch-pipeline.yaml
@@ -1,0 +1,583 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: build-multiarch
+spec:
+  description: |
+    Multi-architecture container image build pipeline. Fans out builds across
+    platforms using `buildah-remote-oci-ta` and assembles a multi-arch manifest
+    via `build-image-index`.
+  params:
+    - description: Source Repository URL
+      name: git-url
+      type: string
+    - default: ""
+      description: Revision of the Source Repository
+      name: revision
+      type: string
+    - description: Fully Qualified Output Image
+      name: output-image
+      type: string
+    - default: .
+      description: Path to the source code of an application's component from where to build image.
+      name: path-context
+      type: string
+    - default: Dockerfile
+      description: Path to the Dockerfile inside the context specified by parameter path-context
+      name: dockerfile
+      type: string
+    - default: "false"
+      description: Force rebuild image
+      name: rebuild
+      type: string
+    - default: "false"
+      description: Skip checks against built image
+      name: skip-checks
+      type: string
+    - default: "false"
+      description: Execute the build with network isolation
+      name: hermetic
+      type: string
+    - default: ""
+      description: Build dependencies to be prefetched
+      name: prefetch-input
+      type: string
+    - default: ""
+      description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
+      name: image-expires-after
+      type: string
+    - default: "false"
+      description: Build a source image.
+      name: build-source-image
+      type: string
+    - default: "false"
+      description: Add built image into an OCI image index
+      name: build-image-index
+      type: string
+    - default: []
+      description: Array of --build-arg values ("arg=value" strings) for buildah
+      name: build-args
+      type: array
+    - default: ""
+      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      name: build-args-file
+      type: string
+    - default: "false"
+      description: Whether to enable privileged mode, should be used only with remote VMs
+      name: privileged-nested
+      type: string
+    - name: buildah-format
+      default: oci
+      type: string
+      description: The format for the resulting image's mediaType. Valid values are oci or docker.
+    - name: enable-cache-proxy
+      default: 'false'
+      description: Enable cache proxy configuration
+      type: string
+    - default:
+        - linux/amd64
+      description: List of platforms to build on. Available values depend on multi-platform-controller configuration.
+      name: build-platforms
+      type: array
+  results:
+    - description: ""
+      name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - description: ""
+      name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - description: ""
+      name: CHAINS-GIT_URL
+      value: $(tasks.clone-repository.results.url)
+    - description: ""
+      name: CHAINS-GIT_COMMIT
+      value: $(tasks.clone-repository.results.commit)
+  tasks:
+    - name: init
+      params:
+        - name: image-url
+          value: $(params.output-image)
+        - name: rebuild
+          value: $(params.rebuild)
+        - name: skip-checks
+          value: $(params.skip-checks)
+        - name: enable-cache-proxy
+          value: $(params.enable-cache-proxy)
+      taskRef:
+        params:
+          - name: name
+            value: init
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:b349d24cb896573695802d6913d311640b44675ec082b3ad167721946a6a0a71
+          - name: kind
+            value: task
+        resolver: bundles
+    - name: clone-repository
+      params:
+        - name: url
+          value: $(params.git-url)
+        - name: revision
+          value: $(params.revision)
+        - name: ociStorage
+          value: $(params.output-image).git
+        - name: ociArtifactExpiresAfter
+          value: $(params.image-expires-after)
+      runAfter:
+        - init
+      taskRef:
+        params:
+          - name: name
+            value: git-clone-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:0a89e1a6304076525e9766f63a4cd006763d21d5aca6863281fc427537a23c6f
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(tasks.init.results.build)
+          operator: in
+          values:
+            - "true"
+      workspaces:
+        - name: basic-auth
+          workspace: git-auth
+    - name: prefetch-dependencies
+      params:
+        - name: input
+          value: $(params.prefetch-input)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+        - name: ociStorage
+          value: $(params.output-image).prefetch
+        - name: ociArtifactExpiresAfter
+          value: $(params.image-expires-after)
+      runAfter:
+        - clone-repository
+      taskRef:
+        params:
+          - name: name
+            value: prefetch-dependencies-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:3e5e834290a1ed57fd14c0082e5a10789c8fe382ed682ef7f981475a7b316b49
+          - name: kind
+            value: task
+        resolver: bundles
+      workspaces:
+        - name: git-basic-auth
+          workspace: git-auth
+        - name: netrc
+          workspace: netrc
+    - name: build-images
+      matrix:
+        params:
+          - name: PLATFORM
+            value:
+              - $(params.build-platforms)
+      params:
+        - name: IMAGE
+          value: $(params.output-image)
+        - name: DOCKERFILE
+          value: $(params.dockerfile)
+        - name: CONTEXT
+          value: $(params.path-context)
+        - name: HERMETIC
+          value: $(params.hermetic)
+        - name: PREFETCH_INPUT
+          value: $(params.prefetch-input)
+        - name: IMAGE_EXPIRES_AFTER
+          value: $(params.image-expires-after)
+        - name: COMMIT_SHA
+          value: $(tasks.clone-repository.results.commit)
+        - name: BUILD_ARGS
+          value:
+            - $(params.build-args[*])
+        - name: BUILD_ARGS_FILE
+          value: $(params.build-args-file)
+        - name: PRIVILEGED_NESTED
+          value: $(params.privileged-nested)
+        - name: IMAGE_APPEND_PLATFORM
+          value: "true"
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+        - name: BUILDAH_FORMAT
+          value: $(params.buildah-format)
+        - name: HTTP_PROXY
+          value: $(tasks.init.results.http-proxy)
+        - name: NO_PROXY
+          value: $(tasks.init.results.no-proxy)
+      runAfter:
+        - prefetch-dependencies
+      taskRef:
+        params:
+          - name: name
+            value: buildah-remote-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.4@sha256:e149741bff59350e110699d9933c5ac8fdb4a9fcacab524e0b12c6653463c938
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(tasks.init.results.build)
+          operator: in
+          values:
+            - "true"
+    - name: build-image-index
+      params:
+        - name: IMAGE
+          value: $(params.output-image)
+        - name: COMMIT_SHA
+          value: $(tasks.clone-repository.results.commit)
+        - name: IMAGE_EXPIRES_AFTER
+          value: $(params.image-expires-after)
+        - name: ALWAYS_BUILD_INDEX
+          value: $(params.build-image-index)
+        - name: IMAGES
+          value:
+            - $(tasks.build-images.results.IMAGE_REF[*])
+        - name: BUILDAH_FORMAT
+          value: $(params.buildah-format)
+      runAfter:
+        - build-images
+      taskRef:
+        params:
+          - name: name
+            value: build-image-index
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.2@sha256:39561ac43e325159497c10c0284cf61dfddf39e39100ca5e3df6b73c5d96db8b
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(tasks.init.results.build)
+          operator: in
+          values:
+            - "true"
+    - name: build-source-image
+      params:
+        - name: BINARY_IMAGE
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: BINARY_IMAGE_DIGEST
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: source-build-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:4abb2dbc9dcfad52d56b490a2f25f99989a2cb2bbd9881223025272db60fd75e
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(tasks.init.results.build)
+          operator: in
+          values:
+            - "true"
+        - input: $(params.build-source-image)
+          operator: in
+          values:
+            - "true"
+    - name: deprecated-base-image-check
+      params:
+        - name: IMAGE_URL
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: IMAGE_DIGEST
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: deprecated-image-check
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:462baed733dfc38aca5395499e92f19b6f13a74c2e88fe5d86c3cffa2f899b57
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
+    - name: clair-scan
+      params:
+        - name: image-digest
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: clair-scan
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:a5fa66ed5b8c107e7bc29cb084edcc07e394f818cc59ef2db2f9dcb0cd1fa3dc
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
+    - name: ecosystem-cert-preflight-checks
+      params:
+        - name: image-url
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: ecosystem-cert-preflight-checks
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:04f75593558f79a27da2336400bc63d460bf0c5669e3c13f40ee2fb650b1ad1e
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
+    - name: sast-snyk-check
+      params:
+        - name: image-digest
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: sast-snyk-check-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:0eca130f289a1a1069a1b92943479f79aa7324e4e68d6396fd777ccd97058f50
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
+    - name: clamav-scan
+      params:
+        - name: image-digest
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: clamav-scan
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:f3d2d179cddcc07d0228d9f52959a233037a3afa2619d0a8b2effbb467db80c3
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
+    - name: sast-coverity-check
+      params:
+        - name: image-digest
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: IMAGE
+          value: $(params.output-image)
+        - name: DOCKERFILE
+          value: $(params.dockerfile)
+        - name: CONTEXT
+          value: $(params.path-context)
+        - name: HERMETIC
+          value: $(params.hermetic)
+        - name: PREFETCH_INPUT
+          value: $(params.prefetch-input)
+        - name: IMAGE_EXPIRES_AFTER
+          value: $(params.image-expires-after)
+        - name: COMMIT_SHA
+          value: $(tasks.clone-repository.results.commit)
+        - name: BUILD_ARGS
+          value:
+            - $(params.build-args[*])
+        - name: BUILD_ARGS_FILE
+          value: $(params.build-args-file)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+        - coverity-availability-check
+      taskRef:
+        params:
+          - name: name
+            value: sast-coverity-check-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:78f5244a8cfd28c890ed62db7e4ff1fc97ff39876d37fb19f1b0c2c286a4002c
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
+        - input: $(tasks.coverity-availability-check.results.STATUS)
+          operator: in
+          values:
+            - success
+    - name: coverity-availability-check
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: coverity-availability-check
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:36400873d3031df128c55aa71ee11d322c3e55fd8f13dc5779098fbc117c0aa3
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
+    - name: sast-shell-check
+      params:
+        - name: image-digest
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: sast-shell-check-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:d44336d7bcbd1f7cedee639357a493bd1f661e2859e49e11a34644bdf6819c4e
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
+    - name: sast-unicode-check
+      params:
+        - name: image-digest
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: sast-unicode-check-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.3@sha256:e5a8d3e8e7be7246a1460385b95c084ea6e8fe7520d40fe4389deb90f1bf5176
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
+    - name: apply-tags
+      params:
+        - name: IMAGE_URL
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: IMAGE_DIGEST
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: apply-tags
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.2@sha256:e4017ec351a0891ef95989f35bd20b8c3f091fa1a3da364c4d4e975e99f3063c
+          - name: kind
+            value: task
+        resolver: bundles
+    - name: push-dockerfile
+      params:
+        - name: IMAGE
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: IMAGE_DIGEST
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        - name: DOCKERFILE
+          value: $(params.dockerfile)
+        - name: CONTEXT
+          value: $(params.path-context)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: push-dockerfile-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:08bba4a659ecd48f871bef00b80af58954e5a09fcbb28a1783ddd640c4f6535e
+          - name: kind
+            value: task
+        resolver: bundles
+    - name: rpms-signature-scan
+      params:
+        - name: image-url
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: image-digest
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: rpms-signature-scan
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:0b10508c82ccb0f5a06a66ce7af56e9bfd40651ddefdf0f499988e897771ee28
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
+  workspaces:
+    - name: git-auth
+      optional: true
+    - name: netrc
+      optional: true

--- a/.tekton/build-multiarch-pipeline.yaml
+++ b/.tekton/build-multiarch-pipeline.yaml
@@ -50,7 +50,7 @@ spec:
       description: Build a source image.
       name: build-source-image
       type: string
-    - default: "false"
+    - default: "true"
       description: Add built image into an OCI image index
       name: build-image-index
       type: string

--- a/.tekton/plumbing-builder-pull-request.yaml
+++ b/.tekton/plumbing-builder-pull-request.yaml
@@ -30,10 +30,14 @@ spec:
       value: Containerfile
     - name: path-context
       value: builder
+    - name: build-platforms
+      value:
+        - linux/amd64
+        - linux/arm64
   timeouts:
     pipeline: 3h
   taskRunSpecs:
-    - pipelineTaskName: build-container
+    - pipelineTaskName: build-images
       timeout: 3h
       stepSpecs:
         - name: build
@@ -51,5 +55,5 @@ spec:
       secret:
         secretName: '{{ git_auth_secret }}'
   pipelineRef:
-    name: build
+    name: build-multiarch
 status: {}

--- a/.tekton/plumbing-builder-push.yaml
+++ b/.tekton/plumbing-builder-push.yaml
@@ -27,10 +27,14 @@ spec:
       value: Containerfile
     - name: path-context
       value: builder
+    - name: build-platforms
+      value:
+        - linux/amd64
+        - linux/arm64
   timeouts:
     pipeline: 3h
   taskRunSpecs:
-    - pipelineTaskName: build-container
+    - pipelineTaskName: build-images
       timeout: 3h
       stepSpecs:
         - name: build
@@ -48,5 +52,5 @@ spec:
       secret:
         secretName: '{{ git_auth_secret }}'
   pipelineRef:
-    name: build
+    name: build-multiarch
 status: {}

--- a/builder/Containerfile
+++ b/builder/Containerfile
@@ -146,7 +146,8 @@ FROM build_base AS build_rust
 COPY build_scripts/build-rust.sh /opt/_internal/build_scripts/
 RUN --mount=type=bind,from=static_clang,target=/tmp/cross-compiler,ro \
     export RUST_VERSION=1.95.0 && \
-    export RUST_HASH=4acc9acc76d5079515b46346a485974457b5a79893cfb01112423c89aeb5aa10 && \
+    export RUST_HASH_x86_64=4acc9acc76d5079515b46346a485974457b5a79893cfb01112423c89aeb5aa10 && \
+    export RUST_HASH_aarch64=9732d6c5e2a098d3521fca8145d826ae0aaa067ef2385ead08e6feac88fa5792 && \
     export RUST_DOWNLOAD_URL=https://static.rust-lang.org/rustup/dist && \
     /tmp/cross-compiler/entrypoint /opt/_internal/build_scripts/build-rust.sh
 

--- a/builder/Containerfile
+++ b/builder/Containerfile
@@ -1,7 +1,7 @@
 # default to latest supported policy, x86_64
 ARG BASEIMAGE=registry.access.redhat.com/ubi8/ubi@sha256:8e573e1d76ff27f9e1219b33c114e48b0f7b86f2e6858cd8861e84431c7416e4
 ARG POLICY=manylinux_2_28
-ARG PLATFORM=x86_64
+ARG PLATFORM=
 ARG DEVTOOLSET_ROOTPATH=/opt/rh/gcc-toolset-14/root
 ARG LD_LIBRARY_PATH_ARG=${DEVTOOLSET_ROOTPATH}/usr/lib64:${DEVTOOLSET_ROOTPATH}/usr/lib:${DEVTOOLSET_ROOTPATH}/usr/lib64/dyninst:${DEVTOOLSET_ROOTPATH}/usr/lib/dyninst
 ARG PREPEND_PATH=/usr/local/bin:${DEVTOOLSET_ROOTPATH}/usr/bin:

--- a/builder/build_scripts/build-rust.sh
+++ b/builder/build_scripts/build-rust.sh
@@ -13,25 +13,29 @@ source "${MY_DIR}/build_utils.sh"
 
 # Install a more recent Rust
 check_var "${RUST_VERSION}"
-check_var "${RUST_HASH}"
 check_var "${RUST_DOWNLOAD_URL}"
 
 PREFIX=/opt/_internal/rust-${RUST_VERSION}
 
-# Download and verify rustup-init
+# Download and verify rustup-init (per-arch binary with per-arch hash)
 RUSTUP_INIT="rustup-init"
 if [ "${AUDITWHEEL_ARCH}" == "x86_64" ]; then
     RUSTUP_ARCH="x86_64-unknown-linux-gnu"
+    RUST_HASH="${RUST_HASH_x86_64}"
 elif [ "${AUDITWHEEL_ARCH}" == "aarch64" ]; then
     RUSTUP_ARCH="aarch64-unknown-linux-gnu"
+    RUST_HASH="${RUST_HASH_aarch64}"
 elif [ "${AUDITWHEEL_ARCH}" == "i686" ]; then
     RUSTUP_ARCH="i686-unknown-linux-gnu"
+    RUST_HASH="${RUST_HASH_i686}"
 elif [ "${AUDITWHEEL_ARCH}" == "armv7l" ]; then
     RUSTUP_ARCH="armv7-unknown-linux-gnueabihf"
+    RUST_HASH="${RUST_HASH_armv7l}"
 else
     echo "Unsupported architecture: ${AUDITWHEEL_ARCH}"
     exit 1
 fi
+check_var "${RUST_HASH}"
 
 fetch_source "${RUSTUP_INIT}" "${RUST_DOWNLOAD_URL}/${RUSTUP_ARCH}"
 check_sha256sum "${RUSTUP_INIT}" "${RUST_HASH}"

--- a/builder/build_scripts/build_utils.sh
+++ b/builder/build_scripts/build_utils.sh
@@ -14,6 +14,11 @@ export BASE_POLICY=manylinux
 PACKAGE_MANAGER=dnf
 OS_ID_LIKE=rhel
 
+# Auto-detect architecture when not explicitly set (multi-arch builds)
+: "${AUDITWHEEL_ARCH:=$(uname -m)}"
+: "${AUDITWHEEL_PLAT:=${AUDITWHEEL_POLICY}_${AUDITWHEEL_ARCH}}"
+export AUDITWHEEL_ARCH AUDITWHEEL_PLAT
+
 function check_var {
 	if [ -z "$1" ]; then
 		echo "required variable not defined"

--- a/builder/build_scripts/build_utils.sh
+++ b/builder/build_scripts/build_utils.sh
@@ -16,7 +16,7 @@ OS_ID_LIKE=rhel
 
 # Auto-detect architecture when not explicitly set (multi-arch builds)
 : "${AUDITWHEEL_ARCH:=$(uname -m)}"
-: "${AUDITWHEEL_PLAT:=${AUDITWHEEL_POLICY}_${AUDITWHEEL_ARCH}}"
+AUDITWHEEL_PLAT="${AUDITWHEEL_POLICY}_${AUDITWHEEL_ARCH}"
 export AUDITWHEEL_ARCH AUDITWHEEL_PLAT
 
 function check_var {

--- a/builder/manylinux-entrypoint
+++ b/builder/manylinux-entrypoint
@@ -2,6 +2,11 @@
 
 set -eu
 
+# Auto-detect architecture when not explicitly set (multi-arch builds)
+: "${AUDITWHEEL_ARCH:=$(uname -m)}"
+: "${AUDITWHEEL_PLAT:=${AUDITWHEEL_POLICY}_${AUDITWHEEL_ARCH}}"
+export AUDITWHEEL_ARCH AUDITWHEEL_PLAT
+
 if [ "${AUDITWHEEL_ARCH}" == "i686" ] && [ "$(uname -m)" == "x86_64" ]; then
 	linux32 "$@"
 elif [ "${AUDITWHEEL_ARCH}" == "armv7l" ] && [ "$(uname -m)" != "armv7l" ]; then

--- a/builder/manylinux-entrypoint
+++ b/builder/manylinux-entrypoint
@@ -4,7 +4,7 @@ set -eu
 
 # Auto-detect architecture when not explicitly set (multi-arch builds)
 : "${AUDITWHEEL_ARCH:=$(uname -m)}"
-: "${AUDITWHEEL_PLAT:=${AUDITWHEEL_POLICY}_${AUDITWHEEL_ARCH}}"
+AUDITWHEEL_PLAT="${AUDITWHEEL_POLICY}_${AUDITWHEEL_ARCH}"
 export AUDITWHEEL_ARCH AUDITWHEEL_PLAT
 
 if [ "${AUDITWHEEL_ARCH}" == "i686" ] && [ "$(uname -m)" == "x86_64" ]; then

--- a/builder/scripts/build-wheels
+++ b/builder/scripts/build-wheels
@@ -83,6 +83,10 @@ if [ "${DEBUG:-}" = "1" ]; then
     set -x
 fi
 
+# Auto-detect architecture for wheel platform matching
+: "${AUDITWHEEL_ARCH:=$(uname -m)}"
+NATIVE_WHL_GLOB="linux_${AUDITWHEEL_ARCH}"
+
 # Logging function with timestamp
 log() {
     echo "[$(date --utc -Ins)] $1" >&2
@@ -169,18 +173,18 @@ for PACKAGE in "${PACKAGES[@]}"; do
     # check for manylinux wheels
     log "Checking for manylinux wheels in need of auditwheel repair"
 
-    if [ -n "$(find wheels-repo/downloads -name '*linux_x86_64.whl' | head -1)" ]; then
+    if [ -n "$(find wheels-repo/downloads -name "*${NATIVE_WHL_GLOB}.whl" | head -1)" ]; then
         log manylinux wheels have been found, auditwheel step required
 
         # Extract shared libraries from wheels so auditwheel can find
         # wheel-internal libs (e.g. pyre's libjournal.so) during repair.
         wheel_libs_dir=$(mktemp -d)
-        for whl in wheels-repo/downloads/*linux_x86_64.whl; do
+        for whl in wheels-repo/downloads/*${NATIVE_WHL_GLOB}.whl; do
             unzip -joq "$whl" '*.so' '*.so.*' -d "$wheel_libs_dir" 2>/dev/null || true
         done
         export LD_LIBRARY_PATH="${wheel_libs_dir}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
-        auditwheel repair wheels-repo/downloads/*linux_x86_64.whl -w wheels-repo/downloads
+        auditwheel repair wheels-repo/downloads/*${NATIVE_WHL_GLOB}.whl -w wheels-repo/downloads
         rm -rf "$wheel_libs_dir"
 
         # auditwheel >= 6.5 embeds CycloneDX SBOMs in repaired wheels by default.
@@ -217,7 +221,7 @@ for PACKAGE in "${PACKAGES[@]}"; do
     # Patch Fromager SBOMs with PURL identifying the wheel and its origin index.
     # Must run after auditwheel repair since the final filename isn't known until then.
     log "Patching Fromager SBOMs: adding PURL and renaming to redhat.spdx.json"
-    # Only patch pure-python and manylinux wheels (skip original linux_x86_64
+    # Only patch pure-python and manylinux wheels (skip original native linux
     # wheels since auditwheel already produced their manylinux replacements).
     for whl in wheels-repo/downloads/*none-any.whl wheels-repo/downloads/*manylinux*.whl; do
         [ -f "$whl" ] || continue


### PR DESCRIPTION
The builder image Containerfile already handles multiple architectures via AUDITWHEEL_ARCH, but the CI pipeline was hardcoded to single-arch buildah-oci-ta. This adds a new build-multiarch pipeline that uses buildah-remote-oci-ta with Tekton matrix fan-out, and makes the Containerfile auto-detect the target architecture from uname -m when PLATFORM is not explicitly set.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Introduce a multi-architecture container image build pipeline and wire CI to use it for builder images.

Enhancements:
- Enable automatic architecture detection in builder scripts and Containerfile when platform is not explicitly specified.

Build:
- Add a Tekton build-multiarch pipeline that fans out builds per platform and assembles a multi-arch image index.
- Update pull request and push Tekton plumbing pipelines to invoke the multi-arch image pipeline and build images for amd64 and arm64.