### PR TITLE
docs: add git source URL examples to build-wheels documentation

### DIFF
--- a/builder/scripts/build-wheels
+++ b/builder/scripts/build-wheels
@@ -30,6 +30,8 @@ EXAMPLES:
     $0 urllib3==2.4.0
     $0 urllib3==2.4.0 requests==2.31.0
     $0 --cache-wheel-server-url https://wheels.example.com urllib3==2.4.0 requests==2.31.0
+    $0 "stevedore @ git+https://github.com/openstack/stevedore.git"
+    $0 "stevedore @ git+https://github.com/openstack/stevedore.git@v3.5.2"
 
 ENVIRONMENT:
     DEBUG=1                        Enable debug mode with verbose output

--- a/tasks/build-python-wheels-oci-ta.yaml
+++ b/tasks/build-python-wheels-oci-ta.yaml
@@ -16,7 +16,7 @@ spec:
   params:
     - name: PACKAGES
       description: >-
-        List of packages to be built. Each is expected to be pinned to a version, e.g. ["urllib3==2.5.0", "numpy==2.3.1"]
+        List of packages to be built. Supports version-pinned packages (e.g. ["urllib3==2.5.0"]) and git source URLs (e.g. ["stevedore @ git+https://github.com/openstack/stevedore.git@v3.5.2"])
       type: array
     - name: IMAGE
       description: Reference of the OCI artifact to be produced.


### PR DESCRIPTION
Fromager supports building packages from git source using PEP 440 URL requirements (e.g. "stevedore @ git+https://..."). Update the help text and Tekton task description to document this capability.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Documentation:
- Clarify build task parameter docs to include examples of git source URL requirements for Python packages.