### PR TITLE
Remove auth credentials from builder wheel cache access

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -161,8 +161,6 @@ spec:
       workspaces:
         - name: git-basic-auth
           workspace: git-auth
-        - name: netrc
-          workspace: netrc
     - name: build-container
       params:
         - name: IMAGE
@@ -567,6 +565,4 @@ spec:
             - "false"
   workspaces:
     - name: git-auth
-      optional: true
-    - name: netrc
       optional: true

--- a/.tekton/bundle-build-pipeline.yaml
+++ b/.tekton/bundle-build-pipeline.yaml
@@ -154,8 +154,6 @@ spec:
       workspaces:
         - name: git-basic-auth
           workspace: git-auth
-        - name: netrc
-          workspace: netrc
     - name: build-container
       params:
         - name: IMAGE
@@ -284,6 +282,4 @@ spec:
         resolver: bundles
   workspaces:
     - name: git-auth
-      optional: true
-    - name: netrc
       optional: true

--- a/builder/scripts/build-wheels
+++ b/builder/scripts/build-wheels
@@ -96,20 +96,6 @@ if [ -f "$ca_bundle" ]; then
     update-ca-trust
 fi
 
-log "Setting up netrc"
-NETRC=~/.netrc
-
-# Only write netrc if both SERVICE_ACCOUNT_USERNAME and SERVICE_ACCOUNT_PASSWORD are set.
-if [ -n "${SERVICE_ACCOUNT_USERNAME:-}" ] && [ -n "${SERVICE_ACCOUNT_PASSWORD:-}" ]; then
-    cat > "$NETRC" <<- EOM
-machine packages.redhat.com login ${SERVICE_ACCOUNT_USERNAME} password ${SERVICE_ACCOUNT_PASSWORD}
-EOM
-    chmod 0600 "$NETRC"
-    log "Wrote netrc for packages.redhat.com"
-else
-    log "SERVICE_ACCOUNT_USERNAME and/or SERVICE_ACCOUNT_PASSWORD not set - skipping netrc setup"
-fi
-
 log "Preparing build environment"
 rm -rf output
 mkdir output

--- a/tasks/build-python-wheels-oci-ta.yaml
+++ b/tasks/build-python-wheels-oci-ta.yaml
@@ -42,11 +42,6 @@ spec:
       description: Optional wheel server URL for prebuilt wheel lookup
       type: string
       default: ""
-    - name: SERVICE_ACCOUNT_SECRET_NAME
-      description: >-
-        Name of the K8s secret containing wheel cache server credentials (keys: username, password)
-      type: string
-      default: builder-service-account
   results:
     - name: IMAGE_DIGEST
       description: Digest of the OCI-Artifact just built
@@ -93,17 +88,6 @@ spec:
         - mountPath: /mnt/trusted-ca
           name: trusted-ca
           readOnly: true
-      env:
-        - name: SERVICE_ACCOUNT_USERNAME
-          valueFrom:
-            secretKeyRef:
-              name: $(params.SERVICE_ACCOUNT_SECRET_NAME)
-              key: username
-        - name: SERVICE_ACCOUNT_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: $(params.SERVICE_ACCOUNT_SECRET_NAME)
-              key: password
       command:
         - build-wheels
       args:


### PR DESCRIPTION
The packages.redhat.com index no longer requires authentication to be used as a wheel cache. Remove the SERVICE_ACCOUNT_SECRET_NAME parameter, netrc setup in build-wheels, and netrc workspace declarations from pipelines.

## Summary by Sourcery

Remove authentication-related configuration for accessing the wheel cache now that the index is publicly accessible.

Enhancements:
- Drop SERVICE_ACCOUNT_SECRET_NAME parameter and associated secret-based environment variables from the build-python-wheels task.
- Remove netrc workspace bindings from build and bundle Tekton pipelines to simplify wheel cache access configuration.