### PR TITLE
Modify output directory to a rw location

### DIFF
--- a/npm-builder/Containerfile
+++ b/npm-builder/Containerfile
@@ -51,7 +51,9 @@ RUN chmod +x /tmp/install-rust-toolset.sh && \
 
 RUN useradd -m -u 1001 -s /bin/bash builder
 
-COPY --chmod=755 scripts/build-npm-package scripts/build-npm-packages scripts/collect-npm-artifacts scripts/npm-publish-pulp /usr/local/bin/
+COPY --chmod=755 scripts/build-npm-package scripts/build-npm-packages scripts/collect-npm-artifacts scripts/collect-npm-package-outputs scripts/record-npm-packages-built scripts/npm-workdir-load.sh scripts/npm-publish-pulp /usr/local/bin/
+COPY --chmod=644 scripts/npm-workdir-env.sh /usr/local/lib/npm-builder/
+ENV NPM_BUILDER_LIB=/usr/local/lib/npm-builder
 
 # rust-toolset + llvm-toolset (dependency) install under /opt/rh/* — same as `scl enable`.
 ENV PATH="/opt/rh/rust-toolset/root/usr/bin:/opt/rh/llvm-toolset/root/usr/bin:/usr/local/bin:${PATH}"

--- a/npm-builder/scripts/build-npm-package
+++ b/npm-builder/scripts/build-npm-package
@@ -7,11 +7,12 @@ usage() {
     cat <<'EOF'
 Usage: build-npm-package --manifest <path> [--workdir <dir>]
 
-Environment (set by Tekton):
+Environment (set by Tekton via build-npm-packages):
   MANIFEST_PATH     Path to manifest.json
-  PACKAGE_DIR       Directory containing manifest + scripts
+  PACKAGE_DIR       Directory containing manifest + scripts (read-only trusted artifact)
+  WORK_DIR          Writable scratch dir for clones/builds (default: ${PACKAGE_DIR}/.work)
+  OUT_DIR           Output directory for tarballs (default: ${PACKAGE_DIR}/out; Tekton: ${OUTPUT_ROOT}/<pkg>)
   SOURCE_DIR        Checkout of source.ref (optional; entrypoint may clone)
-  OUT_DIR           Output directory for tarballs (default: ${PACKAGE_DIR}/out)
 EOF
 }
 
@@ -35,8 +36,9 @@ if [[ -z "${MANIFEST_PATH}" ]]; then
 fi
 
 PACKAGE_DIR="${PACKAGE_DIR:-$(dirname "${MANIFEST_PATH}")}"
+WORK_DIR="${WORK_DIR:-${PACKAGE_DIR}/.work}"
 OUT_DIR="${OUT_DIR:-${PACKAGE_DIR}/out}"
-mkdir -p "${OUT_DIR}"
+mkdir -p "${OUT_DIR}" "${WORK_DIR}"
 
 ENTRYPOINT="${PACKAGE_DIR}/build.entrypoint.sh"
 SMOKE="${PACKAGE_DIR}/verify.smoke.sh"

--- a/npm-builder/scripts/build-npm-packages
+++ b/npm-builder/scripts/build-npm-packages
@@ -9,27 +9,38 @@ usage() {
 Usage: build-npm-packages <pkg-dir> [<pkg-dir>...]
 
 Build onboarder recipes via build-npm-package. Writes package dirs, one per line,
-to BUILT_LIST (default: /var/workdir/built/list.txt).
+to BUILT_LIST (under WORKDIR_ROOT, default /var/workdir/built/list.txt).
+
+Environment:
+  WORKDIR_ROOT   Factory scratch root (Tekton: /var/workdir)
+  SOURCE_ROOT    Onboarding repo checkout (default: ${WORKDIR_ROOT}/source)
+  WORK_ROOT      Writable build scratch (default: ${WORKDIR_ROOT}/work)
+  OUTPUT_ROOT    Factory tarball output (default: ${WORKDIR_ROOT}/output)
 EOF
 }
 
-BUILT_LIST="${BUILT_LIST:-/var/workdir/built/list.txt}"
+# shellcheck source=npm-workdir-load.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/npm-workdir-load.sh"
 
 if [[ $# -lt 1 ]]; then
     usage >&2
     exit 2
 fi
 
-mkdir -p "$(dirname "${BUILT_LIST}")"
+mkdir -p "$(dirname "${BUILT_LIST}")" "${WORK_ROOT}" "${OUTPUT_ROOT}"
 : > "${BUILT_LIST}"
 
 for pkg in "$@"; do
-    manifest="${pkg}/manifest.json"
+    manifest="${SOURCE_ROOT}/${pkg}/manifest.json"
     if [[ ! -f "${manifest}" ]]; then
         echo "Missing manifest: ${manifest}" >&2
         exit 1
     fi
     echo "[build-npm-packages] ${pkg}"
+    WORK_DIR="${WORK_ROOT}/${pkg}" \
+    OUT_DIR="${OUTPUT_ROOT}/${pkg}" \
+    PACKAGE_DIR="${SOURCE_ROOT}/${pkg}" \
+    MANIFEST_PATH="${manifest}" \
     build-npm-package --manifest "${manifest}"
     echo "${pkg}" >> "${BUILT_LIST}"
 done

--- a/npm-builder/scripts/collect-npm-artifacts
+++ b/npm-builder/scripts/collect-npm-artifacts
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 ARTIFACT_DIR="${1:-}"
-OUTPUT_DIR="${2:-/var/workdir/artifact}"
+OUTPUT_DIR="${2:-${ARTIFACT_ROOT:-./artifact}}"
 
 if [[ -z "${ARTIFACT_DIR}" ]]; then
     echo "Usage: collect-npm-artifacts <source-dir> [output-dir]" >&2

--- a/npm-builder/scripts/collect-npm-package-outputs
+++ b/npm-builder/scripts/collect-npm-package-outputs
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Gather factory outputs for all packages listed in BUILT_LIST into ARTIFACT_ROOT.
+set -euo pipefail
+
+# shellcheck source=npm-workdir-load.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/npm-workdir-load.sh"
+
+rm -rf "${ARTIFACT_ROOT}"
+mkdir -p "${ARTIFACT_ROOT}"
+
+if [[ ! -f "${BUILT_LIST}" ]]; then
+    echo "Missing built list: ${BUILT_LIST}" >&2
+    exit 1
+fi
+
+while IFS= read -r pkg; do
+    [[ -n "${pkg}" ]] || continue
+    out="${OUTPUT_ROOT}/${pkg}"
+    if [[ ! -d "${out}" ]]; then
+        echo "Missing factory output for ${pkg}: ${out}" >&2
+        exit 1
+    fi
+    collect-npm-artifacts "${out}" "${ARTIFACT_ROOT}"
+done < "${BUILT_LIST}"
+
+echo "[collect-npm-package-outputs] Collected under ${ARTIFACT_ROOT}"

--- a/npm-builder/scripts/npm-workdir-env.sh
+++ b/npm-builder/scripts/npm-workdir-env.sh
@@ -1,0 +1,23 @@
+# npm-builder factory workdir layout — source from factory scripts; do not execute directly.
+# Tekton sets WORKDIR_ROOT (default /var/workdir). Other paths are derived from it.
+
+npm_workdir_init() {
+    WORKDIR_ROOT="${WORKDIR_ROOT:-/var/workdir}"
+    SOURCE_ROOT="${SOURCE_ROOT:-${WORKDIR_ROOT}/source}"
+    WORK_ROOT="${WORK_ROOT:-${WORKDIR_ROOT}/work}"
+    OUTPUT_ROOT="${OUTPUT_ROOT:-${WORKDIR_ROOT}/output}"
+    ARTIFACT_ROOT="${ARTIFACT_ROOT:-${WORKDIR_ROOT}/artifact}"
+    BUILT_LIST="${BUILT_LIST:-${WORKDIR_ROOT}/built/list.txt}"
+
+    # Local dev: no trusted-artifact checkout — use repo root + .npm-factory scratch dirs.
+    if [[ ! -d "${SOURCE_ROOT}" && -d "${PWD}/packages" ]]; then
+        SOURCE_ROOT="${PWD}"
+        WORKDIR_ROOT="${PWD}/.npm-factory"
+        WORK_ROOT="${WORKDIR_ROOT}/work"
+        OUTPUT_ROOT="${WORKDIR_ROOT}/output"
+        ARTIFACT_ROOT="${WORKDIR_ROOT}/artifact"
+        BUILT_LIST="${WORKDIR_ROOT}/built/list.txt"
+    fi
+
+    export WORKDIR_ROOT SOURCE_ROOT WORK_ROOT OUTPUT_ROOT ARTIFACT_ROOT BUILT_LIST
+}

--- a/npm-builder/scripts/npm-workdir-load.sh
+++ b/npm-builder/scripts/npm-workdir-load.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Resolve npm-workdir-env.sh and initialize factory path variables.
+set -euo pipefail
+
+_npm_builder_env_file() {
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[1]}")" && pwd)"
+    if [[ -f "${script_dir}/npm-workdir-env.sh" ]]; then
+        echo "${script_dir}/npm-workdir-env.sh"
+        return 0
+    fi
+    if [[ -f "${NPM_BUILDER_LIB:-/usr/local/lib/npm-builder}/npm-workdir-env.sh" ]]; then
+        echo "${NPM_BUILDER_LIB:-/usr/local/lib/npm-builder}/npm-workdir-env.sh"
+        return 0
+    fi
+    echo "npm-workdir-env.sh not found" >&2
+    return 1
+}
+
+# shellcheck source=npm-workdir-env.sh
+source "$(_npm_builder_env_file)"
+npm_workdir_init

--- a/npm-builder/scripts/record-npm-packages-built
+++ b/npm-builder/scripts/record-npm-packages-built
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Write comma-separated package list from BUILT_LIST to stdout (Tekton result).
+set -euo pipefail
+
+# shellcheck source=npm-workdir-load.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/npm-workdir-load.sh"
+
+if [[ ! -f "${BUILT_LIST}" ]]; then
+    echo "Missing built list: ${BUILT_LIST}" >&2
+    exit 1
+fi
+
+tr '\n' ',' < "${BUILT_LIST}" | sed 's/,$//'

--- a/tasks/build-npm-package-oci-ta.yaml
+++ b/tasks/build-npm-package-oci-ta.yaml
@@ -45,6 +45,11 @@ spec:
       description: When true, npm publish to Pulp Stage (requires stage secret)
       type: string
       default: "false"
+    - name: WORKDIR_ROOT
+      description: >-
+        Writable emptyDir mount for factory scratch (source checkout, build output, OCI staging)
+      type: string
+      default: /var/workdir
     - name: caTrustConfigMapKey
       type: string
       default: ca-bundle.crt
@@ -71,15 +76,18 @@ spec:
     - name: workdir
       emptyDir: {}
   stepTemplate:
+    env:
+      - name: WORKDIR_ROOT
+        value: $(params.WORKDIR_ROOT)
     volumeMounts:
-      - mountPath: /var/workdir
+      - mountPath: $(params.WORKDIR_ROOT)
         name: workdir
   steps:
     - name: use-trusted-artifact
       image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:2712c8a6453fc9db5fc4c2d9d952554a4eea46d2fdba47a272b79fa07f8c8c40
       args:
         - use
-        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+        - $(params.SOURCE_ARTIFACT)=$(params.WORKDIR_ROOT)/source
       volumeMounts:
         - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
           name: trusted-ca
@@ -87,7 +95,7 @@ spec:
           subPath: ca-bundle.crt
     - name: build-packages
       image: $(params.BUILDER_IMAGE)
-      workingDir: /var/workdir/source
+      workingDir: $(params.WORKDIR_ROOT)/source
       command:
         - build-npm-packages
       args:
@@ -101,20 +109,8 @@ spec:
           memory: 4Gi
     - name: collect-artifacts
       image: $(params.BUILDER_IMAGE)
-      script: |
-        #!/usr/bin/env bash
-        set -euo pipefail
-        rm -rf /var/workdir/artifact
-        mkdir -p /var/workdir/artifact
-        while IFS= read -r pkg; do
-          [[ -n "${pkg}" ]] || continue
-          out="/var/workdir/source/${pkg}/out"
-          if [[ ! -d "${out}" ]]; then
-            echo "Missing out/ for ${pkg}" >&2
-            exit 1
-          fi
-          collect-npm-artifacts "${out}" "/var/workdir/artifact"
-        done < /var/workdir/built/list.txt
+      command:
+        - collect-npm-package-outputs
       computeResources:
         limits:
           memory: 2Gi
@@ -136,7 +132,7 @@ spec:
           memory: 256Mi
     - name: create-oci-artifact
       image: quay.io/konflux-ci/oras:latest@sha256:1beeecce012c99794568f74265c065839f9703d28306a8430b667f639343a98b
-      workingDir: /var/workdir
+      workingDir: $(params.WORKDIR_ROOT)
       volumeMounts:
         - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
           name: trusted-ca
@@ -159,7 +155,8 @@ spec:
         EXPIRE_LABEL=()
         [ -n "$IMAGE_EXPIRES_AFTER" ] && EXPIRE_LABEL=("--annotation" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
 
-        cd artifact
+        ARTIFACT_ROOT="${ARTIFACT_ROOT:-${WORKDIR_ROOT}/artifact}"
+        cd "${ARTIFACT_ROOT}"
 
         echo "Pushing OCI artifact to ${IMAGE}"
         if ! retry oras push "$IMAGE" \
@@ -226,7 +223,8 @@ spec:
           echo "PULP_NPM_REGISTRY_URL is required when PUBLISH_TO_PULP=true" >&2
           exit 1
         fi
-        npm-publish-pulp /var/workdir/artifact
+        ARTIFACT_ROOT="${ARTIFACT_ROOT:-${WORKDIR_ROOT}/artifact}"
+        npm-publish-pulp "${ARTIFACT_ROOT}"
       computeResources:
         limits:
           memory: 1Gi
@@ -238,8 +236,7 @@ spec:
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
-        list="$(tr '\n' ',' < /var/workdir/built/list.txt | sed 's/,$//')"
-        echo -n "${list}" | tee "$(results.PACKAGES_BUILT.path)"
+        record-npm-packages-built | tee "$(results.PACKAGES_BUILT.path)"
       computeResources:
         limits:
           memory: 256Mi


### PR DESCRIPTION
Making sure output directory is read/write

## Summary by Sourcery

Update the npm package OCI build task to write build outputs to a dedicated writable output directory.

Enhancements:
- Expose SOURCE_ROOT, WORK_ROOT, and OUTPUT_ROOT environment variables to the npm package build step to standardize working locations.
- Change the output path for built npm packages from the source tree to a separate output directory under /var/workdir/output.