### PR TITLE
Adding wrapper for shasum to npm builder

### DIFF
--- a/npm-builder/Containerfile
+++ b/npm-builder/Containerfile
@@ -51,6 +51,7 @@ RUN chmod +x /tmp/install-rust-toolset.sh && \
 
 RUN useradd -m -u 1001 -s /bin/bash builder
 
+COPY --chmod=755 scripts/shasum /usr/local/bin/shasum
 COPY --chmod=755 scripts/build-npm-package scripts/build-npm-packages scripts/collect-npm-artifacts scripts/collect-npm-package-outputs scripts/record-npm-packages-built scripts/npm-workdir-load.sh scripts/npm-publish-pulp /usr/local/bin/
 COPY --chmod=644 scripts/npm-workdir-env.sh /usr/local/lib/npm-builder/
 ENV NPM_BUILDER_LIB=/usr/local/lib/npm-builder

--- a/npm-builder/scripts/shasum
+++ b/npm-builder/scripts/shasum
@@ -1,0 +1,6 @@
+#!/bin/sh
+# esbuild's Makefile calls shasum (Perl, common on macOS). UBI provides sha256sum only.
+if [ "$1" = "-a" ] && [ "$2" = "256" ]; then
+    shift 2
+fi
+exec sha256sum "$@"


### PR DESCRIPTION
Found a gap in dependency already (shasum) where package make requires it.

## Summary by Sourcery

Build:
- Include the shasum wrapper script in the npm-builder Containerfile so it is installed into /usr/local/bin during image build.