### PR TITLE
Adding new trusted task policy for npm

### DIFF
--- a/policy-data/trusted_task_rules.yaml
+++ b/policy-data/trusted_task_rules.yaml
@@ -9,3 +9,4 @@ trusted_task_rules:
   allow:
     calunga-build-tasks:
       - pattern: oci://quay.io/redhat-user-workloads/calunga-tenant/task-build-python-wheels*
+      - pattern: oci://quay.io/redhat-user-workloads/calunga-tenant/task-build-npm-package*


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Add support for calunga npm package build task in trusted_task_rules configuration.