### PR TITLE
Replace deprecated buildah-task with task-runner

### DIFF
--- a/tasks/install-and-import-wheels.yaml
+++ b/tasks/install-and-import-wheels.yaml
@@ -29,7 +29,7 @@ spec:
         mountPath: /var/workdir
   steps:
     - name: get-image-urls
-      image: quay.io/konflux-ci/buildah-task:latest@sha256:b82d465a06c926882d02b721cf8a8476048711332749f39926a01089cf85a3f9
+      image: quay.io/konflux-ci/task-runner:2.1.0@sha256:c34c933c269e2401bb042fe69e2999cf288331b6586d4f4eca9c845270d9b1f9
       script: |
         #!/bin/bash
         set -euo pipefail


### PR DESCRIPTION
The buildah-task image is deprecated and no longer maintained by the Konflux Build team. Replaced with task-runner, which is the recommended drop-in replacement.

## Summary by Sourcery

Build:
- Switch CI task image from buildah-task to the recommended task-runner image for wheel installation and import.