### PR TITLE
Add --package-settings-dir option to build-wheels

### DIFF
--- a/builder/scripts/build-wheels
+++ b/builder/scripts/build-wheels
@@ -3,6 +3,7 @@ set -euo pipefail
 
 # Initialize variables
 WHEEL_SERVER_URL=""
+PACKAGE_SETTINGS_DIR=""
 PACKAGES=()
 BUILD_SEQUENCE_SUMMARIES=()
 
@@ -24,6 +25,7 @@ ARGUMENTS:
 
 OPTIONS:
     --cache-wheel-server-url URL    Optional wheel cache server URL for faster builds
+    --package-settings-dir DIR      Optional directory of per-package fromager settings
     --help                          Show this help message
 
 EXAMPLES:
@@ -58,6 +60,14 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             WHEEL_SERVER_URL="$2"
+            shift 2
+            ;;
+        --package-settings-dir)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: --package-settings-dir requires a value" >&2
+                exit 1
+            fi
+            PACKAGE_SETTINGS_DIR="$2"
             shift 2
             ;;
         -*)
@@ -123,9 +133,13 @@ for PACKAGE in "${PACKAGES[@]}"; do
     log "Resolving dependencies and creating build order"
     fromager_args=(
         --settings-file /usr/local/share/fromager/overrides/settings.yaml
-        bootstrap
-        "${PACKAGE}"
     )
+
+    if [ -n "$PACKAGE_SETTINGS_DIR" ]; then
+        fromager_args+=(--settings-dir "$PACKAGE_SETTINGS_DIR")
+    fi
+
+    fromager_args+=(bootstrap "${PACKAGE}")
 
     # Add wheel server URL if provided
     if [ -n "$WHEEL_SERVER_URL" ]; then
@@ -138,9 +152,13 @@ for PACKAGE in "${PACKAGES[@]}"; do
     log "Building wheels from build order"
     fromager_build_args=(
         --settings-file /usr/local/share/fromager/overrides/settings.yaml
-        build-sequence
-        work-dir/build-order.json
     )
+
+    if [ -n "$PACKAGE_SETTINGS_DIR" ]; then
+        fromager_build_args+=(--settings-dir "$PACKAGE_SETTINGS_DIR")
+    fi
+
+    fromager_build_args+=(build-sequence work-dir/build-order.json)
 
     if [ -n "$WHEEL_SERVER_URL" ]; then
         fromager_build_args+=(--cache-wheel-server-url "$WHEEL_SERVER_URL")

--- a/tasks/build-python-wheels-oci-ta.yaml
+++ b/tasks/build-python-wheels-oci-ta.yaml
@@ -42,6 +42,10 @@ spec:
       description: Optional wheel server URL for prebuilt wheel lookup
       type: string
       default: ""
+    - name: PACKAGE_SETTINGS_DIR
+      description: Optional directory of per-package fromager settings (e.g. build_dir for monorepo packages)
+      type: string
+      default: /var/workdir/source/overrides/settings
   results:
     - name: IMAGE_DIGEST
       description: Digest of the OCI-Artifact just built
@@ -94,6 +98,8 @@ spec:
         - $(params.PACKAGES[*])
         - --cache-wheel-server-url
         - $(params.WHEEL_SERVER_URL)
+        - --package-settings-dir
+        - $(params.PACKAGE_SETTINGS_DIR)
     - name: collect-build-files
       image: quay.io/redhat-user-workloads/calunga-tenant/plumbing-builder@sha256:abe5804fbc5073ea3d7999523d4eae9c44cd290c5fb0450969d2b7e4627789bf
       command:


### PR DESCRIPTION
Allow per-package fromager settings (e.g. build_dir for monorepo packages) to be passed from the source checkout. The Tekton task always passes the index repo's overrides/settings directory.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Build:
- Update the Tekton build-python-wheels task to always pass a package settings directory from the source checkout to the build-wheels script.