### PR TITLE
feat(builder): add fromager plugin and patches for faiss-cpu

### DIFF
--- a/builder/Containerfile
+++ b/builder/Containerfile
@@ -383,6 +383,9 @@ RUN venv/bin/python -m pip install -r requirements.txt --no-deps --no-cache-dir 
 
 COPY scripts/* /usr/local/bin/
 COPY overrides/settings.yaml /usr/local/share/fromager/overrides/settings.yaml
+COPY overrides/patches /usr/local/share/fromager/overrides/patches
+COPY overrides/package_plugins /src/package_plugins
+RUN venv/bin/pip install --no-deps /src/package_plugins
 
 RUN \
     ln -s /src/venv/bin/python /usr/local/bin/python3 && \

--- a/builder/overrides/package_plugins/pyproject.toml
+++ b/builder/overrides/package_plugins/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "calunga-package-plugins"
+version = "0.1.0"
+
+[project.entry-points."fromager.project_overrides"]
+faiss_cpu = "package_plugins.faiss_cpu"

--- a/builder/overrides/package_plugins/src/package_plugins/faiss_cpu.py
+++ b/builder/overrides/package_plugins/src/package_plugins/faiss_cpu.py
@@ -122,7 +122,8 @@ def build_wheel(  # noqa: PLR0913
 
     faiss_prefix = sdist_root_dir / "_faiss_install"
     cmake_build = sdist_root_dir / "_cmake_build"
-    jobs = max(1, ctx.settings.max_jobs or multiprocessing.cpu_count())
+    _max = ctx.settings.max_jobs
+    jobs = max(1, _max if _max is not None else multiprocessing.cpu_count())
     opt_level = _faiss_opt_level()
 
     logger.info(

--- a/builder/overrides/package_plugins/src/package_plugins/faiss_cpu.py
+++ b/builder/overrides/package_plugins/src/package_plugins/faiss_cpu.py
@@ -1,0 +1,193 @@
+"""faiss-cpu fromager override plugin.
+
+Before v1.14.2, PyPI wheels were built by https://github.com/faiss-wheels/faiss-wheels
+using a custom build strategy. This plugin reproduces that strategy exactly to
+preserve binary compatibility with the published wheels.
+
+From v1.14.2 onward, https://github.com/facebookresearch/faiss publishes wheels
+directly via scikit-build-core; that path is handled by standard PEP-517.
+
+Build strategy by version:
+
+  < 1.14.2 (faiss-wheels/faiss-wheels era):
+    1. cmake FAISS_ENABLE_PYTHON=OFF + FAISS_OPT_LEVEL=avx512 (Linux x86_64)
+    2. cmake --install -> local prefix (libfaiss.a)
+    3. cmake FAISS_ENABLE_PYTHON=ON -> _swigfaiss.so linked against libfaiss.a
+    4. PEP-517 wheel from cmake output dir
+    5. Retag py3-none-any -> linux_x86_64 -> auditwheel -> manylinux_2_*_x86_64
+
+  >= 1.14.2 (facebookresearch/faiss upstream era):
+    scikit-build-core pyproject.toml -> standard PEP-517, no custom cmake.
+
+"""
+
+import functools
+import logging
+import multiprocessing
+import pathlib
+import platform as _platform
+import sys
+from collections.abc import Iterable
+
+from fromager import build_environment, context, wheels
+from fromager.dependencies import default_get_build_backend_dependencies
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+logger = logging.getLogger(__name__)
+
+_OPENBLAS_PREFIX = "/opt/_internal/openblas-0"
+_KYAMAGU_CXXFLAGS = "-fvisibility=hidden -fdata-sections -ffunction-sections"
+_SCIKIT_BUILD_CORE_MIN = Version("1.14.2")
+
+
+@functools.cache
+def _uses_scikit_build_core(sdist_root_dir: pathlib.Path) -> bool:
+    pyproject = sdist_root_dir / "pyproject.toml"
+    if not pyproject.exists():
+        return False
+    return "scikit_build_core" in pyproject.read_text()
+
+
+def _faiss_opt_level() -> str:
+    return "avx512" if _platform.machine() == "x86_64" else "generic"
+
+
+def _retag_wheel(
+    wheel_path: pathlib.Path,
+    build_env: build_environment.BuildEnvironment,
+) -> pathlib.Path:
+    py_ver = f"cp{sys.version_info.major}{sys.version_info.minor}"
+    machine = _platform.machine()
+    logger.info(
+        "faiss-cpu: retagging %s -> %s-%s-linux_%s",
+        wheel_path.name, py_ver, py_ver, machine,
+    )
+    build_env.run(
+        [
+            str(build_env.python), "-m", "wheel", "tags",
+            "--python-tag", py_ver,
+            "--abi-tag", py_ver,
+            "--platform-tag", f"linux_{machine}",
+            "--remove",
+            str(wheel_path),
+        ],
+        cwd=str(wheel_path.parent),
+    )
+    pattern = f"faiss_cpu-*-{py_ver}-{py_ver}-linux_{machine}.whl"
+    found = list(wheel_path.parent.glob(pattern))
+    if not found:
+        msg = f"Retagged wheel not found in {wheel_path.parent} (pattern: {pattern})"
+        raise RuntimeError(msg)
+    logger.info("faiss-cpu: retagged -> %s", found[0].name)
+    return found[0]
+
+
+def get_build_backend_dependencies(  # noqa: PLR0913
+    ctx: context.WorkContext,
+    req: Requirement,
+    sdist_root_dir: pathlib.Path,
+    build_dir: pathlib.Path,
+    extra_environ: dict,
+    build_env: build_environment.BuildEnvironment,
+) -> Iterable[str]:
+    """Return build backend deps; skip setup.py interrogation for legacy builds."""
+    if _uses_scikit_build_core(sdist_root_dir):
+        logger.info("faiss-cpu: scikit-build-core detected, using default deps")
+        return default_get_build_backend_dependencies(
+            ctx=ctx, req=req, sdist_root_dir=sdist_root_dir,
+            build_dir=build_dir, extra_environ=extra_environ, build_env=build_env,
+        )
+    logger.info("faiss-cpu: legacy kyamagu build, declaring numpy + wheel")
+    return ["numpy", "wheel"]
+
+
+def build_wheel(  # noqa: PLR0913
+    ctx: context.WorkContext,
+    build_env: build_environment.BuildEnvironment,
+    extra_environ: dict,
+    req: Requirement,
+    sdist_root_dir: pathlib.Path,
+    version: Version,
+    build_dir: pathlib.Path,
+) -> pathlib.Path:
+    """Build faiss-cpu wheel following the kyamagu/faiss-wheels process."""
+    if version >= _SCIKIT_BUILD_CORE_MIN:
+        logger.info("faiss-cpu %s: scikit-build-core, default PEP-517", version)
+        return wheels.default_build_wheel(
+            ctx=ctx, build_env=build_env, extra_environ=extra_environ,
+            req=req, sdist_root_dir=sdist_root_dir,
+            version=version, build_dir=build_dir,
+        )
+
+    faiss_prefix = sdist_root_dir / "_faiss_install"
+    cmake_build = sdist_root_dir / "_cmake_build"
+    jobs = max(1, ctx.settings.max_jobs or multiprocessing.cpu_count())
+    opt_level = _faiss_opt_level()
+
+    logger.info(
+        "faiss-cpu: cmake PYTHON=OFF FAISS_OPT_LEVEL=%s -j%d", opt_level, jobs,
+    )
+    build_env.run(
+        [
+            "cmake", str(sdist_root_dir), "-B", str(cmake_build),
+            "-DFAISS_ENABLE_GPU=OFF",
+            "-DFAISS_ENABLE_PYTHON=OFF",
+            "-DBUILD_TESTING=OFF",
+            f"-DFAISS_OPT_LEVEL={opt_level}",
+            "-DCMAKE_BUILD_TYPE=Release",
+            f"-DCMAKE_CXX_FLAGS={_KYAMAGU_CXXFLAGS}",
+            f"-DCMAKE_PREFIX_PATH={_OPENBLAS_PREFIX}",
+            f"-DCMAKE_INSTALL_PREFIX={faiss_prefix}",
+        ],
+        cwd=str(sdist_root_dir),
+        extra_environ=extra_environ,
+    )
+    build_env.run(
+        ["cmake", "--build", str(cmake_build), f"-j{jobs}"],
+        extra_environ=extra_environ,
+    )
+    build_env.run(
+        ["cmake", "--install", str(cmake_build)],
+        extra_environ=extra_environ,
+    )
+
+    cmake_python_build = sdist_root_dir / "_cmake_python_build"
+    logger.info(
+        "faiss-cpu: cmake PYTHON=ON FAISS_OPT_LEVEL=%s -j%d", opt_level, jobs,
+    )
+    build_env.run(
+        [
+            "cmake", str(sdist_root_dir), "-B", str(cmake_python_build),
+            "-DFAISS_ENABLE_GPU=OFF",
+            "-DFAISS_ENABLE_PYTHON=ON",
+            "-DBUILD_TESTING=OFF",
+            f"-DFAISS_OPT_LEVEL={opt_level}",
+            "-DCMAKE_BUILD_TYPE=Release",
+            f"-DCMAKE_PREFIX_PATH={faiss_prefix};{_OPENBLAS_PREFIX}",
+            "-DSWIG_EXECUTABLE=/usr/local/bin/swig",
+            f"-DPython_EXECUTABLE={build_env.python}",
+        ],
+        cwd=str(sdist_root_dir),
+        extra_environ=extra_environ,
+    )
+    build_env.run(
+        [
+            "cmake", "--build", str(cmake_python_build),
+            "--target", "swigfaiss", f"-j{jobs}",
+        ],
+        extra_environ=extra_environ,
+    )
+
+    cmake_python_dir = cmake_python_build / "faiss" / "python"
+    logger.info("faiss-cpu: PEP-517 wheel from %s", cmake_python_dir)
+    wheel_path = wheels.pep517_build_wheel(
+        ctx=ctx,
+        build_env=build_env,
+        extra_environ=extra_environ,
+        req=req,
+        sdist_root_dir=sdist_root_dir,
+        version=version,
+        build_dir=cmake_python_dir,
+    )
+    return _retag_wheel(wheel_path, build_env)

--- a/builder/overrides/patches/faiss_cpu-1.9.0/001-add-pyproject-toml.patch
+++ b/builder/overrides/patches/faiss_cpu-1.9.0/001-add-pyproject-toml.patch
@@ -1,0 +1,13 @@
+--- /dev/null
++++ b/pyproject.toml
+@@ -0,0 +1,10 @@
++[build-system]
++requires = ["setuptools>=40.8.0"]
++build-backend = "setuptools.build_meta"
++
++[project]
++name = "faiss-cpu"
++version = "1.9.0"
++
++[tool.setuptools]
++packages = []

--- a/builder/overrides/patches/faiss_cpu-1.9.0/002-rename-package-to-faiss-cpu.patch
+++ b/builder/overrides/patches/faiss_cpu-1.9.0/002-rename-package-to-faiss-cpu.patch
@@ -1,0 +1,9 @@
+--- a/faiss/python/setup.py
++++ b/faiss/python/setup.py
+@@ -51,7 +51,7 @@ long_description="""
+ """
+ setup(
+-    name='faiss',
++    name='faiss-cpu',
+     version='1.9.0',
+     description='A library for efficient similarity search and clustering of dense vectors',

--- a/builder/overrides/patches/faiss_cpu/010-use-python-development-module-only.patch
+++ b/builder/overrides/patches/faiss_cpu/010-use-python-development-module-only.patch
@@ -1,0 +1,8 @@
+--- a/faiss/python/CMakeLists.txt
++++ b/faiss/python/CMakeLists.txt
+@@ -229,7 +229,7 @@ target_include_directories(swigfaiss_sve PRIVATE ${PROJECT_SOURCE_DIR}/../..)
+
+ find_package(Python REQUIRED
+-  COMPONENTS Development NumPy
++  COMPONENTS Development.Module NumPy
+ )

--- a/builder/scripts/build-wheels
+++ b/builder/scripts/build-wheels
@@ -4,6 +4,7 @@ set -euo pipefail
 # Initialize variables
 WHEEL_SERVER_URL=""
 PACKAGE_SETTINGS_DIR=""
+MAX_JOBS=""
 PACKAGES=()
 BUILD_SEQUENCE_SUMMARIES=()
 
@@ -26,6 +27,7 @@ ARGUMENTS:
 OPTIONS:
     --cache-wheel-server-url URL    Optional wheel cache server URL for faster builds
     --package-settings-dir DIR      Optional directory of per-package fromager settings
+    --max-jobs N                    Maximum parallel jobs for builds (default: all CPUs)
     --help                          Show this help message
 
 EXAMPLES:
@@ -68,6 +70,14 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             PACKAGE_SETTINGS_DIR="$2"
+            shift 2
+            ;;
+        --max-jobs)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: --max-jobs requires a value" >&2
+                exit 1
+            fi
+            MAX_JOBS="$2"
             shift 2
             ;;
         -*)
@@ -139,6 +149,15 @@ for PACKAGE in "${PACKAGES[@]}"; do
         fromager_args+=(--settings-dir "$PACKAGE_SETTINGS_DIR")
     fi
 
+    _builtin_patches_dir=/usr/local/share/fromager/overrides/patches
+    if [ -d "$_builtin_patches_dir" ]; then
+        fromager_args+=(--patches-dir "$_builtin_patches_dir")
+    fi
+
+    if [ -n "$MAX_JOBS" ]; then
+        fromager_args+=(--jobs "$MAX_JOBS")
+    fi
+
     fromager_args+=(bootstrap "${PACKAGE}")
 
     # Add wheel server URL if provided
@@ -156,6 +175,14 @@ for PACKAGE in "${PACKAGES[@]}"; do
 
     if [ -n "$PACKAGE_SETTINGS_DIR" ]; then
         fromager_build_args+=(--settings-dir "$PACKAGE_SETTINGS_DIR")
+    fi
+
+    if [ -d "$_builtin_patches_dir" ]; then
+        fromager_build_args+=(--patches-dir "$_builtin_patches_dir")
+    fi
+
+    if [ -n "$MAX_JOBS" ]; then
+        fromager_build_args+=(--jobs "$MAX_JOBS")
     fi
 
     fromager_build_args+=(build-sequence work-dir/build-order.json)


### PR DESCRIPTION
## Summary

- Add `fromager.project_overrides` plugin for `faiss-cpu` following the [faiss-wheels/faiss-wheels](https://github.com/faiss-wheels/faiss-wheels) build strategy (< v1.14.2) and upstream [facebookresearch/faiss](https://github.com/facebookresearch/faiss) scikit-build-core strategy (>= v1.14.2)
- Two-phase cmake build: `FAISS_ENABLE_PYTHON=OFF` + avx512 → `libfaiss.a`, then `FAISS_ENABLE_PYTHON=ON` → `_swigfaiss.so`
- Three patches: add `pyproject.toml` (fixes setuptools auto-discovery), rename `faiss` → `faiss-cpu`, use `Development.Module` in cmake
- Add `--patches-dir` (baked-in patches) and `--max-jobs` / `--jobs` to `build-wheels` script

## Test plan

- [ ] CI builds new `plumbing-builder` image with plugin installed
- [ ] Verify `fromager.project_overrides` entry point `faiss_cpu` is registered in image

## Summary by Sourcery

Add a fromager override plugin and baked-in patches to build faiss-cpu wheels with the legacy two-phase CMake strategy when needed while supporting standard scikit-build-core builds for newer versions.

New Features:
- Introduce a faiss-cpu fromager project_overrides plugin that reproduces the legacy kyamagu/faiss-wheels build process when scikit-build-core is not used.
- Register the plugin via a dedicated package-plugins project with an entry point for fromager.project_overrides and install it into the builder image.
- Add baked-in patch directories for faiss-cpu to adjust packaging metadata and CMake behavior across specific versions.

Enhancements:
- Wire the builder container to copy and install override patches and package plugins into the image so they are available during wheel builds.