### PR TITLE
Support C++ 20 via gcc 14

### DIFF
--- a/npm-builder/Containerfile
+++ b/npm-builder/Containerfile
@@ -41,10 +41,18 @@ RUN dnf -y module enable nodejs:20 && \
         && dnf clean all \
         && rm -rf /var/cache/dnf
 
+# gcc-toolset pin: edit gcc-toolset.lock only (single source of truth).
+COPY gcc-toolset.lock build_scripts/install-gcc-toolset.sh /tmp/
+RUN chmod +x /tmp/install-gcc-toolset.sh && \
+    /tmp/install-gcc-toolset.sh && \
+    rm -f /tmp/install-gcc-toolset.sh /tmp/gcc-toolset.lock && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
+
 # Rust version pin: edit rust-toolset.lock only (single source of truth).
 COPY rust-toolset.lock build_scripts/install-rust-toolset.sh /tmp/
 RUN chmod +x /tmp/install-rust-toolset.sh && \
-    RUST_TOOLSET_LOCK=/tmp/rust-toolset.lock /tmp/install-rust-toolset.sh && \
+    /tmp/install-rust-toolset.sh && \
     rm -f /tmp/install-rust-toolset.sh /tmp/rust-toolset.lock && \
     dnf clean all && \
     rm -rf /var/cache/dnf
@@ -56,8 +64,12 @@ COPY --chmod=755 scripts/build-npm-package scripts/build-npm-packages scripts/co
 COPY --chmod=644 scripts/npm-workdir-env.sh /usr/local/lib/npm-builder/
 ENV NPM_BUILDER_LIB=/usr/local/lib/npm-builder
 
-# rust-toolset + llvm-toolset (dependency) install under /opt/rh/* — same as `scl enable`.
-ENV PATH="/opt/rh/rust-toolset/root/usr/bin:/opt/rh/llvm-toolset/root/usr/bin:/usr/local/bin:${PATH}"
+# gcc-toolset + rust-toolset + llvm-toolset under /opt/rh/* — node-gyp uses CC/CXX.
+# GCC_TOOLSET must match gcc-toolset.lock (currently 14).
+ENV GCC_TOOLSET_ROOT=/opt/rh/gcc-toolset-14/root \
+    CC=/opt/rh/gcc-toolset-14/root/usr/bin/gcc \
+    CXX=/opt/rh/gcc-toolset-14/root/usr/bin/g++ \
+    PATH="/opt/rh/gcc-toolset-14/root/usr/bin:/opt/rh/rust-toolset/root/usr/bin:/opt/rh/llvm-toolset/root/usr/bin:/usr/local/bin:${PATH}"
 
 WORKDIR /work
 USER builder

--- a/npm-builder/README.md
+++ b/npm-builder/README.md
@@ -13,8 +13,9 @@ downloads from `static.rust-lang.org`.
 | UBI 8 base | `registry.access.redhat.com/ubi8/ubi` | digest in [`baseimage.lock`](./baseimage.lock) + Containerfile `ARG BASEIMAGE` |
 | Node.js 20 LTS | AppStream `nodejs:20` module | stream `20` |
 | Go | AppStream `golang` | distro default |
+| **C/C++ (node-gyp)** | **gcc-toolset-14** (CodeReady Builder) | toolset version in [`gcc-toolset.lock`](./gcc-toolset.lock); C++20 on UBI 8 glibc |
 | **Rust** | AppStream **`rust-toolset`** module | **exact RPM VR** in [`rust-toolset.lock`](./rust-toolset.lock) |
-| C/C++ / node-gyp | `gcc`, `python3`, `openssl-devel`, etc. | — |
+| node-gyp deps | `python3`, `openssl-devel`, stock `make`, etc. | stock gcc remains installed; **`CC`/`CXX`** point at toolset |
 
 ### Rust pinning (RHEL 8)
 
@@ -31,7 +32,11 @@ use epoch `(none)`; we pin by installing exact version-release specs, then
 digest in Containerfile `ARG BASEIMAGE` (required before `FROM`; buildkit cannot
 read the lock file into that line).
 
-To refresh the lock file from current UBI (uses `baseimage.lock` as the query image).
+**Edit [`gcc-toolset.lock`](./gcc-toolset.lock) when bumping gcc-toolset** — set
+`GCC_TOOLSET` and update Containerfile `ENV` paths
+(`/opt/rh/gcc-toolset-${GCC_TOOLSET}/...`).
+
+To refresh the rust lock file from current UBI (uses `baseimage.lock` as the query image).
 Requires `docker` on the host (`CONTAINER_RUNTIME=podman` also works):
 
 ```bash
@@ -49,8 +54,10 @@ docker run --rm --platform linux/amd64 "$(grep BASEIMAGE= baseimage.lock | cut -
 pinned VR disappears, the image build fails until you bump `rust-toolset.lock` —
 that is intentional.
 
-The Python `plumbing-builder` uses **rustup** from the internet for a specific
-version; this npm image deliberately uses **Red Hat RPMs only**.
+The Python **`plumbing-builder`** uses the same **gcc-toolset-14** pattern for manylinux
+wheels. npm-builder reuses it so Tier C addons (e.g. **better-sqlite3 ≥ 11.2**) can
+compile with **C++20** without moving the base image to UBI 9. For Rust, **`plumbing-builder`**
+uses **rustup** from the internet; this npm image deliberately uses **Red Hat RPMs only**.
 
 ## Quay
 
@@ -68,7 +75,9 @@ quay.io/redhat-user-workloads/calunga-tenant/npm-builder:<tag>
 | `build-npm-packages` | Build multiple package dirs (Tekton `PACKAGES` args) |
 | `collect-npm-artifacts` | Stage `out/*.tgz` for OCI push / optional Pulp publish |
 | `npm-publish-pulp` | Optional Pulp npm publish (deferred; Tekton step only) |
+| `build_scripts/install-gcc-toolset.sh` | Install gcc-toolset from `gcc-toolset.lock` |
 | `build_scripts/install-rust-toolset.sh` | Install + versionlock pinned rust-toolset RPMs |
+| `hack/update-rust-toolset-lock.sh` | Refresh `rust-toolset.lock` from UBI |
 
 Publishing to Quay (OCI artifact), optional Pulp, and cosign are handled in **Tekton steps**, not in these scripts.
 
@@ -80,6 +89,8 @@ Requires `docker` on the host (`CONTAINER_RUNTIME=podman ./hack/update-rust-tool
 docker build -t npm-builder -f Containerfile .
 docker run --rm npm-builder node --version
 docker run --rm npm-builder go version
+docker run --rm npm-builder g++ --version
+docker run --rm npm-builder bash -c 'echo | g++ -std=c++20 -x c++ - -o /dev/null -'
 docker run --rm npm-builder rustc --version
 docker run --rm npm-builder cargo --version
 ```

--- a/npm-builder/build_scripts/install-gcc-toolset.sh
+++ b/npm-builder/build_scripts/install-gcc-toolset.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Install gcc-toolset for node-gyp / Tier C native builds (C++20 on UBI 8).
+# Keeps UBI 8 glibc for published .node runtime; only the compiler is newer.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -n "${GCC_TOOLSET_LOCK:-}" ]]; then
+    LOCK_FILE="${GCC_TOOLSET_LOCK}"
+elif [[ -f "${SCRIPT_DIR}/gcc-toolset.lock" ]]; then
+    LOCK_FILE="${SCRIPT_DIR}/gcc-toolset.lock"
+else
+    LOCK_FILE="${SCRIPT_DIR}/../gcc-toolset.lock"
+fi
+
+if [[ -f "${LOCK_FILE}" ]]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "${LOCK_FILE}"
+    set +a
+fi
+
+GCC_TOOLSET="${GCC_TOOLSET:-14}"
+GCC_TOOLSET_ROOT="/opt/rh/gcc-toolset-${GCC_TOOLSET}/root"
+GXX="${GCC_TOOLSET_ROOT}/usr/bin/g++"
+GCC="${GCC_TOOLSET_ROOT}/usr/bin/gcc"
+
+dnf -y install dnf-plugins-core
+dnf config-manager --set-enabled ubi-8-codeready-builder-rpms 2>/dev/null || \
+    dnf config-manager --set-enabled codeready-builder-for-rhel-8-*-rpms 2>/dev/null || \
+    dnf config-manager --set-enabled powertools 2>/dev/null || true
+
+dnf -y install \
+    --setopt install_weak_deps=0 \
+    "gcc-toolset-${GCC_TOOLSET}-binutils" \
+    "gcc-toolset-${GCC_TOOLSET}-gcc" \
+    "gcc-toolset-${GCC_TOOLSET}-gcc-c++" \
+    "gcc-toolset-${GCC_TOOLSET}-libatomic-devel"
+
+[[ -x "${GXX}" ]] || {
+    echo "Missing ${GXX}" >&2
+    exit 1
+}
+
+# Verify C++20 (required by better-sqlite3 >= 11.2 and similar node-gyp addons).
+cat >/tmp/npm-builder-cxx20-test.cpp <<'EOF'
+#include <version>
+int main() { return __cplusplus >= 202002L ? 0 : 1; }
+EOF
+"${GXX}" -std=c++20 -o /tmp/npm-builder-cxx20-test /tmp/npm-builder-cxx20-test.cpp
+/tmp/npm-builder-cxx20-test
+rm -f /tmp/npm-builder-cxx20-test /tmp/npm-builder-cxx20-test.cpp
+
+echo "Installed gcc-toolset-${GCC_TOOLSET} for npm-builder (C++20 OK)"
+"${GCC}" --version | head -1
+"${GXX}" --version | head -1

--- a/npm-builder/build_scripts/install-rust-toolset.sh
+++ b/npm-builder/build_scripts/install-rust-toolset.sh
@@ -3,7 +3,13 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-LOCK_FILE="${RUST_TOOLSET_LOCK:-${SCRIPT_DIR}/../rust-toolset.lock}"
+if [[ -n "${RUST_TOOLSET_LOCK:-}" ]]; then
+    LOCK_FILE="${RUST_TOOLSET_LOCK}"
+elif [[ -f "${SCRIPT_DIR}/rust-toolset.lock" ]]; then
+    LOCK_FILE="${SCRIPT_DIR}/rust-toolset.lock"
+else
+    LOCK_FILE="${SCRIPT_DIR}/../rust-toolset.lock"
+fi
 
 if [[ -f "${LOCK_FILE}" ]]; then
     set -a

--- a/npm-builder/gcc-toolset.lock
+++ b/npm-builder/gcc-toolset.lock
@@ -1,0 +1,3 @@
+# gcc-toolset major version from UBI CodeReady Builder (Red Hat only).
+# Also update Containerfile ENV paths (/opt/rh/gcc-toolset-${GCC_TOOLSET}/...).
+GCC_TOOLSET=14


### PR DESCRIPTION
Latest versions of tier C npm package failed cause we don't have C++20 support.

## Summary by Sourcery

Add gcc-toolset-14 to the npm-builder image to provide C++20-capable compilers for node-gyp native builds while keeping UBI 8 as the base.

New Features:
- Provide C++20 support for Tier C node-gyp addons (e.g. better-sqlite3) via gcc-toolset-14 in the npm-builder image.

Enhancements:
- Expose gcc-toolset-14 compilers in the container environment via CC/CXX and PATH for native build tooling.
- Align npm-builder with plumbing-builder’s gcc-toolset pattern for consistent native build tooling across images.

Documentation:
- Update npm-builder README to document gcc-toolset-14 usage, C++20 support, and new verification commands.

Tests:
- Add a gcc-toolset installation script that includes a C++20 smoke test to verify toolchain capabilities during image build.

Chores:
- Extend the local docker run examples to exercise the installed C++20-capable g++ in the npm-builder image.