### PR TITLE
Support uploading attestations for existing packages in Pulp

### DIFF
--- a/pipelines/calunga-backfill-attestations.yaml
+++ b/pipelines/calunga-backfill-attestations.yaml
@@ -1,0 +1,229 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: calunga-backfill-attestations
+spec:
+  description: >-
+    One-time remediation pipeline: generate and upload attestations for
+    packages already in Pulp that are missing provenance (June 24 incident).
+    Skips EC verification (old snapshots use deprecated task digests).
+  params:
+    - name: release
+      type: string
+      description:
+        The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution
+    - name: releasePlan
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlan
+    - name: releasePlanAdmission
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlanAdmission
+    - name: releaseServiceConfig
+      type: string
+      description: The namespaced name (namespace/name) of the releaseServiceConfig
+    - name: snapshot
+      type: string
+      description: The namespaced name (namespace/name) of the snapshot
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+      default: https://github.com/konflux-ci/release-service-catalog.git
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+      default: production
+    - name: pulpBaseUrl
+      type: string
+      default: https://packages.redhat.com
+    - name: pulpDomain
+      type: string
+      default: public-trusted-libraries
+    - name: pulpApiRoot
+      type: string
+      default: "/api/"
+    - name: serviceAccountSecretName
+      type: string
+      default: rhtl-pulp-credentials-secret
+    - name: pulpRepository
+      type: string
+      default: main
+    - name: signingSecretName
+      type: string
+      default: konflux-cosign-signing-production
+    - name: config
+      type: string
+      default: release-pipeline-config
+  tasks:
+
+    - name: config
+      taskRef:
+        params:
+          - name: name
+            value: get-config
+          - name: bundle
+            value: quay.io/redhat-user-workloads/calunga-tenant/task-get-config@sha256:abe408d7365a23a548268b994dc7d758660fc595ba6af0f455f000a4f3f535d7
+          - name: kind
+            value: task
+        resolver: bundles
+      params:
+        - name: configMapName
+          value: $(params.config)
+
+    - name: collect-data
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/collect-data/collect-data.yaml
+      params:
+        - name: release
+          value: $(params.release)
+        - name: releasePlan
+          value: $(params.releasePlan)
+        - name: releasePlanAdmission
+          value: $(params.releasePlanAdmission)
+        - name: releaseServiceConfig
+          value: $(params.releaseServiceConfig)
+        - name: snapshot
+          value: $(params.snapshot)
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: $(params.taskGitUrl)
+        - name: taskGitRevision
+          value: $(params.taskGitRevision)
+        - name: ociStorage
+          value: $(tasks.config.results.ociStorage)
+
+    - name: reduce-snapshot
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/reduce-snapshot/reduce-snapshot.yaml
+      params:
+        - name: SNAPSHOT
+          value: $(workspaces.data.path)/$(tasks.collect-data.results.snapshotSpec)
+        - name: SINGLE_COMPONENT
+          value: $(tasks.collect-data.results.singleComponentMode)
+        - name: SINGLE_COMPONENT_CUSTOM_RESOURCE
+          value: snapshot/$(tasks.collect-data.results.snapshotName)
+        - name: SINGLE_COMPONENT_CUSTOM_RESOURCE_NS
+          value: $(tasks.collect-data.results.snapshotNamespace)
+        - name: SNAPSHOT_PATH
+          value: $(workspaces.data.path)/$(tasks.collect-data.results.snapshotSpec)
+        - name: taskGitUrl
+          value: $(params.taskGitUrl)
+        - name: taskGitRevision
+          value: $(params.taskGitRevision)
+        - name: sourceDataArtifact
+          value: "$(tasks.collect-data.results.sourceDataArtifact)"
+        - name: ociStorage
+          value: $(tasks.config.results.ociStorage)
+      runAfter:
+        - collect-data
+
+    - name: extract-py-artifacts
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/extract-py-artifacts/extract-py-artifacts.yaml
+      params:
+        - name: SNAPSHOT_PATH
+          value: $(tasks.collect-data.results.snapshotSpec)
+        - name: sourceDataArtifact
+          value: "$(tasks.reduce-snapshot.results.sourceDataArtifact)"
+        - name: ociStorage
+          value: $(tasks.config.results.ociStorage)
+        - name: taskGitUrl
+          value: $(params.taskGitUrl)
+        - name: taskGitRevision
+          value: $(params.taskGitRevision)
+        - name: dataDir
+          value: /var/workdir/content
+        - name: dataPath
+          value: $(tasks.collect-data.results.data)
+      runAfter:
+        - reduce-snapshot
+
+    - name: rh-sign-python-wheels
+      timeout: "2h00m0s"
+      when:
+        - input: $(params.signingSecretName)
+          operator: notin
+          values: [""]
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/rh-sign-python-wheels/rh-sign-python-wheels.yaml
+      params:
+        - name: secretName
+          value: "$(params.signingSecretName)"
+        - name: sourceDataArtifact
+          value: "$(tasks.extract-py-artifacts.results.sourceDataArtifact)"
+        - name: ociStorage
+          value: $(tasks.config.results.ociStorage)
+        - name: taskGitUrl
+          value: $(params.taskGitUrl)
+        - name: taskGitRevision
+          value: $(params.taskGitRevision)
+      runAfter:
+        - extract-py-artifacts
+
+    - name: upload-attestations
+      when:
+        - input: $(params.signingSecretName)
+          operator: notin
+          values: [""]
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/calungaproject/plumbing.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/upload-attestations-pulp.yaml
+      params:
+        - name: PULP_BASE_URL
+          value: $(params.pulpBaseUrl)
+        - name: PULP_API_ROOT
+          value: $(params.pulpApiRoot)
+        - name: PULP_DOMAIN
+          value: $(params.pulpDomain)
+        - name: SERVICE_ACCOUNT_SECRET_NAME
+          value: $(params.serviceAccountSecretName)
+        - name: PULP_REPOSITORY
+          value: $(params.pulpRepository)
+        - name: sourceDataArtifact
+          value: "$(tasks.rh-sign-python-wheels.results.sourceDataArtifact)"
+        - name: dataDir
+          value: /var/workdir/content
+        - name: taskGitUrl
+          value: $(params.taskGitUrl)
+        - name: taskGitRevision
+          value: $(params.taskGitRevision)
+        - name: ociStorage
+          value: $(tasks.config.results.ociStorage)
+      runAfter:
+        - rh-sign-python-wheels
+

--- a/tasks/upload-attestations-pulp.yaml
+++ b/tasks/upload-attestations-pulp.yaml
@@ -1,0 +1,172 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: upload-attestations-pulp
+spec:
+  description: |
+    Upload attestations to Pulp for packages that already exist but are
+    missing provenance. One-time remediation for the June 24 bulk-upload
+    incident.
+  params:
+    - name: SERVICE_ACCOUNT_SECRET_NAME
+      type: string
+      description: >-
+        The name of the secret containing the terms-based registry service account credentials
+      default: rhtl-pulp-credentials-secret
+    - name: PULP_BASE_URL
+      type: string
+      description: The base URL of the Pulp server
+    - name: PULP_API_ROOT
+      type: string
+      description: The API root path of the Pulp server
+      default: "/api/"
+    - name: PULP_DOMAIN
+      type: string
+      description: The domain to use for Pulp operations
+    - name: PULP_REPOSITORY
+      type: string
+      description: The Pulp repository to upload to
+    - name: sourceDataArtifact
+      type: string
+      description: Trusted Artifact containing the signed wheels and attestations
+    - name: dataDir
+      type: string
+      description: The location where data will be stored
+      default: /var/workdir
+    - name: filesDir
+      type: string
+      description: The relative path within dataDir where wheel files are located
+      default: files
+    - name: ociArtifactExpiresAfter
+      type: string
+      description: Expiration date for the trusted artifacts created
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: ""
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable
+      type: string
+      default: ""
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+    - name: ociStorage
+      type: string
+      description: The OCI repository where the Trusted Artifacts are stored
+  results:
+    - description: Produced trusted data artifact
+      name: sourceDataArtifact
+      type: string
+  volumes:
+    - name: service-account-secret
+      secret:
+        secretName: $(params.SERVICE_ACCOUNT_SECRET_NAME)
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    securityContext:
+      runAsUser: 1001
+    env:
+      - name: PULP_BASE_URL
+        value: $(params.PULP_BASE_URL)
+      - name: PULP_API_ROOT
+        value: $(params.PULP_API_ROOT)
+      - name: PULP_DOMAIN
+        value: $(params.PULP_DOMAIN)
+      - name: PULP_REPOSITORY
+        value: $(params.PULP_REPOSITORY)
+      - name: FILES_DIR
+        value: $(params.dataDir)/$(params.filesDir)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.ociArtifactExpiresAfter)
+      - name: "ORAS_OPTIONS"
+        value: "$(params.orasOptions)"
+      - name: "DEBUG"
+        value: "$(params.trustedArtifactsDebug)"
+    volumeMounts:
+      - name: service-account-secret
+        mountPath: "/etc/service-account-secret"
+        readOnly: true
+      - name: workdir
+        mountPath: /var/workdir
+  steps:
+    - name: prepare-workdir
+      image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      computeResources:
+        limits:
+          memory: 32Mi
+          cpu: 10m
+        requests:
+          memory: 32Mi
+          cpu: 10m
+      command:
+        - mkdir
+        - -p
+        - $(params.dataDir)
+    - name: use-trusted-artifact
+      computeResources:
+        limits:
+          memory: 64Mi
+          cpu: 10m
+        requests:
+          memory: 64Mi
+          cpu: 10m
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: stepactions/use-trusted-artifact/use-trusted-artifact.yaml
+      params:
+        - name: workDir
+          value: $(params.dataDir)
+        - name: sourceDataArtifact
+          value: $(params.sourceDataArtifact)
+    - name: upload-attestations
+      image: quay.io/redhat-user-workloads/calunga-tenant/plumbing-utils@sha256:48c6eff749812d5757933f2f16448866923e15c7d8f5ff88539760b0cc290ba1
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        TWINE_USERNAME=$(< /etc/service-account-secret/username)
+        TWINE_PASSWORD=$(< /etc/service-account-secret/password)
+        export TWINE_USERNAME TWINE_PASSWORD
+        pulp-upload-attestations
+      computeResources:
+        limits:
+          memory: 256Mi
+          cpu: 100m
+        requests:
+          memory: 256Mi
+          cpu: 100m
+    - name: create-trusted-artifact
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          memory: 128Mi
+          cpu: 250m
+      ref:
+        resolver: "git"
+        params:
+          - name: url
+            value: "$(params.taskGitUrl)"
+          - name: revision
+            value: "$(params.taskGitRevision)"
+          - name: pathInRepo
+            value: stepactions/create-trusted-artifact/create-trusted-artifact.yaml
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: workDir
+          value: $(params.dataDir)
+        - name: sourceDataArtifact
+          value: $(results.sourceDataArtifact.path)

--- a/utils/scripts/pulp-upload-attestations
+++ b/utils/scripts/pulp-upload-attestations
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+#
+# Upload attestations to Pulp for packages that already exist but are
+# missing provenance. This is a one-time remediation script for the
+# June 24 bulk-upload incident where packages were pushed without
+# attestations.
+#
+# This script does NOT upload wheels — it only uploads .attestation
+# files via the Pulp provenance content API.
+#
+# Expected env vars (same as pulp-upload):
+#   FILES_DIR, PULP_BASE_URL, PULP_API_ROOT, PULP_DOMAIN,
+#   PULP_REPOSITORY, TWINE_USERNAME, TWINE_PASSWORD
+set -euo pipefail
+
+cd "${FILES_DIR}"
+ls -la .
+
+PULP_QUERY_BASE="${PULP_BASE_URL}${PULP_API_ROOT}pulp/${PULP_DOMAIN}/api/v3/"
+
+REPO_JSON=$( curl --fail --silent --retry 3 --max-time 30 "${PULP_QUERY_BASE}repositories/python/python/" )
+PULP_REPOSITORY_VERSION=$( echo "$REPO_JSON" \
+    | jq -r ".results[] | select(.name==\"${PULP_REPOSITORY}\") | .latest_version_href" )
+PULP_REPOSITORY_HREF=$( echo "$REPO_JSON" \
+    | jq -r ".results[] | select(.name==\"${PULP_REPOSITORY}\") | .pulp_href" )
+
+shopt -s nullglob
+
+uploaded=()
+skipped_has_provenance=()
+skipped_not_in_pulp=()
+skipped_no_attestation=()
+failed=()
+
+for file in *.whl *.tar.gz; do
+    if [[ ! -f "${file}.attestation" ]]; then
+        echo "Skipping $file - no attestation file"
+        skipped_no_attestation+=("$file")
+        continue
+    fi
+
+    PACKAGE_RESPONSE=$( curl --fail --silent --retry 3 --max-time 30 -G \
+        "${PULP_QUERY_BASE}content/python/packages/" --data-urlencode "filename=${file}" \
+        --data-urlencode "repository_version=${PULP_REPOSITORY_VERSION}" )
+    WHEEL_EXISTS=$( echo "$PACKAGE_RESPONSE" | jq '.results | length != 0' )
+
+    if ! $WHEEL_EXISTS; then
+        echo "Skipping ${file} - not found in Pulp"
+        skipped_not_in_pulp+=("$file")
+        continue
+    fi
+
+    PACKAGE_HREF=$( echo "$PACKAGE_RESPONSE" | jq -r '.results[0].pulp_href' )
+
+    PROVENANCE_RESPONSE=$( curl --fail --silent --retry 3 --max-time 30 -G \
+        "${PULP_QUERY_BASE}content/python/provenance/" \
+        --data-urlencode "package=${PACKAGE_HREF}" \
+        --data-urlencode "repository_version=${PULP_REPOSITORY_VERSION}" 2>/dev/null ) || true
+    if [ -z "$PROVENANCE_RESPONSE" ]; then
+        echo "WARNING: Could not check provenance for ${file}, attempting upload anyway"
+        HAS_PROVENANCE=false
+    else
+        HAS_PROVENANCE=$( echo "$PROVENANCE_RESPONSE" | jq '.results | length != 0' )
+    fi
+
+    if $HAS_PROVENANCE; then
+        echo "Skipping ${file} - already has provenance"
+        skipped_has_provenance+=("$file")
+        continue
+    fi
+
+    echo "Uploading attestation for ${file}..."
+    if curl --fail --retry 3 --max-time 60 \
+        -u "${TWINE_USERNAME}:${TWINE_PASSWORD}" \
+        -X POST \
+        -F "file=@${file}.attestation" \
+        -F "package=${PACKAGE_HREF}" \
+        -F "repository=${PULP_REPOSITORY_HREF}" \
+        "${PULP_QUERY_BASE}content/python/provenance/"; then
+        echo "Uploaded attestation for ${file}"
+        uploaded+=("$file")
+    else
+        echo "ERROR: Failed to upload attestation for ${file}"
+        failed+=("$file")
+    fi
+done
+
+echo ""
+echo "=============================="
+echo "  Attestation Upload Summary"
+echo "=============================="
+echo ""
+echo "Uploaded attestation (${#uploaded[@]}):"
+for f in "${uploaded[@]+"${uploaded[@]}"}"; do
+    echo "  - $f"
+done
+echo ""
+echo "Skipped - already has provenance (${#skipped_has_provenance[@]}):"
+for f in "${skipped_has_provenance[@]+"${skipped_has_provenance[@]}"}"; do
+    echo "  - $f"
+done
+echo ""
+echo "Skipped - not in Pulp (${#skipped_not_in_pulp[@]}):"
+for f in "${skipped_not_in_pulp[@]+"${skipped_not_in_pulp[@]}"}"; do
+    echo "  - $f"
+done
+echo ""
+echo "Skipped - no attestation file (${#skipped_no_attestation[@]}):"
+for f in "${skipped_no_attestation[@]+"${skipped_no_attestation[@]}"}"; do
+    echo "  - $f"
+done
+echo ""
+echo "Failed (${#failed[@]}):"
+for f in "${failed[@]+"${failed[@]}"}"; do
+    echo "  - $f"
+done
+
+if [[ ${#failed[@]} -gt 0 ]]; then
+    echo ""
+    echo "ERROR: ${#failed[@]} attestation upload(s) failed"
+    exit 1
+fi


### PR DESCRIPTION
When a wheel already exists in Pulp but is missing a provenance object, upload just the attestation via the Pulp provenance API instead of skipping the package entirely. Packages that already have both a wheel and provenance are still skipped.

## Summary by Sourcery

Update Python wheel build task to use a new plumbing-builder container image digest and keep test tooling aligned with the same image reference.

Build:
- Switch build and collect-build-files Tekton task steps to the updated plumbing-builder image digest.

Tests:
- Update test harness image pullspec to match the new plumbing-builder image used by the build tasks.