### PR TITLE
feat(builder): add Apache Arrow C++ 25.0.0 build stage for pyarrow support

### DIFF
--- a/builder/Containerfile
+++ b/builder/Containerfile
@@ -151,6 +151,15 @@ RUN --mount=type=bind,from=static_clang,target=/tmp/cross-compiler,ro \
     /tmp/cross-compiler/entrypoint /opt/_internal/build_scripts/build-rust.sh
 
 
+FROM build_base AS build_arrow
+COPY build_scripts/build-arrow.sh /opt/_internal/build_scripts/
+RUN --mount=type=bind,from=static_clang,target=/tmp/cross-compiler,ro \
+    export ARROW_VERSION=25.0.0 && \
+    export ARROW_HASH=12afc2dc8137bdd4a68876cec939f664c9d55cfc7b75f55b45163ebb4e344d81 && \
+    export ARROW_DOWNLOAD_URL=https://archive.apache.org/dist/arrow/arrow-25.0.0 && \
+    /tmp/cross-compiler/entrypoint /opt/_internal/build_scripts/build-arrow.sh
+
+
 FROM build_base AS build_libjpeg_turbo
 COPY build_scripts/build-libjpeg-turbo.sh /opt/_internal/build_scripts/
 RUN --mount=type=bind,from=static_clang,target=/tmp/cross-compiler,ro \
@@ -283,6 +292,7 @@ COPY --from=build_libxslt /manylinux-buildfs /
 COPY --from=build_libffi /manylinux-buildfs /
 COPY --from=build_openblas /manylinux-buildfs /
 COPY --from=build_libomp /manylinux-buildfs /
+COPY --from=build_arrow /manylinux-buildfs /
 ARG MANYLINUX_DISABLE_CLANG_FOR_CPYTHON
 RUN --mount=type=bind,from=static_clang,target=/tmp/cross-compiler,ro \
     /tmp/cross-compiler/entrypoint /opt/_internal/build_scripts/build-cpython.sh thomas@python.org https://accounts.google.com 3.12.12
@@ -300,6 +310,7 @@ COPY --from=build_libxslt /manylinux-buildfs /
 COPY --from=build_libffi /manylinux-buildfs /
 COPY --from=build_openblas /manylinux-buildfs /
 COPY --from=build_libomp /manylinux-buildfs /
+COPY --from=build_arrow /manylinux-buildfs /
 
 
 FROM runtime_base
@@ -320,6 +331,7 @@ COPY --from=build_libxslt /manylinux-rootfs /
 COPY --from=build_libffi /manylinux-rootfs /
 COPY --from=build_openblas /manylinux-rootfs /
 COPY --from=build_libomp /manylinux-rootfs /
+COPY --from=build_arrow /manylinux-rootfs /
 RUN find /opt/_internal -name '*.so' -printf '%h\n' | sort -u >> /etc/ld.so.conf.d/00-manylinux.conf && \
     ldconfig
 

--- a/builder/build_scripts/build-arrow.sh
+++ b/builder/build_scripts/build-arrow.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Top-level build script called from Dockerfile
+
+# Stop at any error, show all commands
+set -exuo pipefail
+
+# Get script directory
+MY_DIR=$(dirname "${BASH_SOURCE[0]}")
+
+# Get build utilities
+# shellcheck source-path=SCRIPTDIR
+source "${MY_DIR}/build_utils.sh"
+
+# Build Apache Arrow C++ library (required by pyarrow)
+check_var "${ARROW_VERSION}"
+check_var "${ARROW_HASH}"
+check_var "${ARROW_DOWNLOAD_URL}"
+ARROW_ROOT="apache-arrow-${ARROW_VERSION}"
+
+PREFIX=/usr/local
+
+fetch_source "${ARROW_ROOT}.tar.gz" "${ARROW_DOWNLOAD_URL}"
+check_sha256sum "${ARROW_ROOT}.tar.gz" "${ARROW_HASH}"
+tar xfz "${ARROW_ROOT}.tar.gz"
+pushd "${ARROW_ROOT}/cpp"
+
+cmake -S . -B build \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+    -DCMAKE_INSTALL_LIBDIR=lib \
+    -DARROW_BUILD_STATIC=OFF \
+    -DARROW_BUILD_SHARED=ON \
+    -DARROW_COMPUTE=ON \
+    -DARROW_CSV=ON \
+    -DARROW_DATASET=ON \
+    -DARROW_HDFS=ON \
+    -DARROW_JSON=ON \
+    -DARROW_PARQUET=ON \
+    -DARROW_WITH_SNAPPY=ON \
+    -DARROW_WITH_LZ4=ON \
+    -DARROW_WITH_ZSTD=ON \
+    -DARROW_WITH_ZLIB=ON \
+    -DARROW_WITH_BZ2=ON \
+    -DARROW_WITH_BROTLI=ON \
+    -DARROW_WITH_RE2=ON \
+    -DARROW_WITH_UTF8PROC=ON \
+    -DARROW_DEPENDENCY_SOURCE=BUNDLED \
+    -DCMAKE_C_FLAGS="${MANYLINUX_CFLAGS}" \
+    -DCMAKE_CXX_FLAGS="${MANYLINUX_CXXFLAGS}" > /dev/null
+
+cmake --build build --parallel "$(nproc)" > /dev/null
+DESTDIR=/manylinux-rootfs cmake --install build > /dev/null
+popd
+rm -rf "${ARROW_ROOT}" "${ARROW_ROOT}.tar.gz"
+
+# Add rpath to pkgconfig so pkg-config consumers get the rpath automatically
+for pc in /manylinux-rootfs"${PREFIX}"/lib/pkgconfig/{arrow,parquet}*.pc; do
+    if [ -f "$pc" ]; then
+        sed -i "s|^Libs:|Libs: -Wl,--enable-new-dtags,-rpath=\${libdir} |g" "$pc"
+    fi
+done
+
+# Strip what we can
+strip_ /manylinux-rootfs
+
+# Install for build
+mkdir /manylinux-buildfs
+cp -rlf /manylinux-rootfs/* /manylinux-buildfs/
+
+# Clean-up for runtime (keep libs, drop headers, pkgconfig, cmake config and debug/doc files)
+rm -rf /manylinux-rootfs"${PREFIX}"/include/arrow
+rm -rf /manylinux-rootfs"${PREFIX}"/include/parquet
+rm -rf /manylinux-rootfs"${PREFIX}"/lib/pkgconfig/arrow*.pc
+rm -rf /manylinux-rootfs"${PREFIX}"/lib/pkgconfig/parquet*.pc
+rm -rf /manylinux-rootfs"${PREFIX}"/lib/cmake/Arrow
+rm -rf /manylinux-rootfs"${PREFIX}"/lib/cmake/ArrowAcero
+rm -rf /manylinux-rootfs"${PREFIX}"/lib/cmake/ArrowCompute
+rm -rf /manylinux-rootfs"${PREFIX}"/lib/cmake/ArrowDataset
+rm -rf /manylinux-rootfs"${PREFIX}"/lib/cmake/Parquet
+rm -rf /manylinux-rootfs"${PREFIX}"/share/arrow
+rm -rf /manylinux-rootfs"${PREFIX}"/share/doc/arrow


### PR DESCRIPTION
Required for building `pyarrow` from source. Without Arrow C++, pyarrow's cmake fails with `ArrowConfig.cmake not found`.

## Design

Arrow C++ is installed to `/usr/local` (not `/opt/_internal/`) so that `find_package(Arrow)` works out of the box — cmake searches `/usr/local/lib/cmake/` by default. Alternatives considered and rejected:

- **Symlink `/usr/local/lib/cmake/Arrow` → `/opt/_internal/`**: cmake computes `_IMPORT_PREFIX` from the symlink path, causing `ArrowTargets.cmake` to reference `/usr/local/lib/libarrow.so` which doesn't exist there.
- **`env: CMAKE_PREFIX_PATH` in per-package settings**: inconsistent with repo conventions, creates fragile dependency between index settings and builder image paths.

Precedent: `build-git.sh` installs to `/usr/local` directly.

## CMake flags

Components enabled (replacements for deprecated `ARROW_PYTHON=ON`): `COMPUTE`, `CSV`, `DATASET`, `HDFS`, `JSON`. `ARROW_DEPENDENCY_SOURCE=BUNDLED` — no system deps required.

## Runtime

Headers, cmake configs, and pkg-config files stripped from `/manylinux-rootfs` (runtime layer). Shared libs kept.

## Summary by Sourcery

Add a new Apache Arrow C++ build stage to the builder image to support building pyarrow from source and include its shared libraries in the final runtime image while stripping build-only artifacts.

New Features:
- Introduce a build stage that compiles and installs Apache Arrow C++ 25.0.0 into the manylinux builder and runtime images for pyarrow support.

Enhancements:
- Ensure Apache Arrow shared libraries are installed under /usr/local with appropriate rpath and separated build/runtime filesystem layouts, removing headers and configuration files from the runtime layer to keep it lean.