### PR TITLE
Add SBOM generation logic to include with npm pkgs

### DIFF
--- a/npm-builder/Containerfile
+++ b/npm-builder/Containerfile
@@ -60,7 +60,7 @@ RUN chmod +x /tmp/install-rust-toolset.sh && \
 RUN useradd -m -u 1001 -s /bin/bash builder
 
 COPY --chmod=755 scripts/shasum /usr/local/bin/shasum
-COPY --chmod=755 scripts/build-npm-package scripts/build-npm-packages scripts/collect-npm-artifacts scripts/collect-npm-package-outputs scripts/record-npm-packages-built scripts/npm-workdir-load.sh scripts/npm-publish-pulp /usr/local/bin/
+COPY --chmod=755 scripts/build-npm-package scripts/build-npm-packages scripts/collect-npm-artifacts scripts/collect-npm-package-outputs scripts/generate-npm-sbom scripts/record-npm-packages-built scripts/npm-workdir-load.sh scripts/npm-publish-pulp /usr/local/bin/
 COPY --chmod=644 scripts/npm-workdir-env.sh /usr/local/lib/npm-builder/
 ENV NPM_BUILDER_LIB=/usr/local/lib/npm-builder
 

--- a/npm-builder/README.md
+++ b/npm-builder/README.md
@@ -74,12 +74,15 @@ quay.io/redhat-user-workloads/calunga-tenant/npm-builder:<tag>
 | `build-npm-package` | Run entrypoint + smoke for one manifest |
 | `build-npm-packages` | Build multiple package dirs (Tekton `PACKAGES` args) |
 | `collect-npm-artifacts` | Stage `out/*.tgz` for OCI push / optional Pulp publish |
+| `generate-npm-sbom` | Embed CycloneDX into each collected `.tgz` (`package/sboms/*.cdx.json`) |
 | `npm-publish-pulp` | Optional Pulp npm publish (deferred; Tekton step only) |
 | `build_scripts/install-gcc-toolset.sh` | Install gcc-toolset from `gcc-toolset.lock` |
 | `build_scripts/install-rust-toolset.sh` | Install + versionlock pinned rust-toolset RPMs |
 | `hack/update-rust-toolset-lock.sh` | Refresh `rust-toolset.lock` from UBI |
 
-Publishing to Quay (OCI artifact), optional Pulp, and cosign are handled in **Tekton steps**, not in these scripts.
+Publishing to Quay (OCI artifact) and optional Pulp are handled in **Tekton steps**.
+Package attestations are **release-phase** (like Python `rh-sign-python-wheels`); see
+`utils/scripts/generate-and-sign-npm-attestations`.
 
 ## Local build
 

--- a/npm-builder/scripts/generate-npm-sbom
+++ b/npm-builder/scripts/generate-npm-sbom
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Embed a CycloneDX 1.5 SBOM into each collected npm package tarball.
+# Mirrors Python's build-time SPDX-in-wheel: every published artifact (main and
+# platform/binary packages) gets package/sboms/<name>-<version>.cdx.json.
+#
+# Usage: generate-npm-sbom [artifact-dir]
+# Default: ARTIFACT_ROOT (or ./artifact)
+set -euo pipefail
+
+ARTIFACT_DIR="${1:-${ARTIFACT_ROOT:-./artifact}}"
+
+if [[ ! -d "${ARTIFACT_DIR}" ]]; then
+    echo "[generate-npm-sbom] missing artifact dir: ${ARTIFACT_DIR}" >&2
+    exit 1
+fi
+
+tgz_files=()
+while IFS= read -r f; do
+    [[ -n "${f}" ]] && tgz_files+=("$f")
+done < <(find "${ARTIFACT_DIR}" -type f -name '*.tgz' | LC_ALL=C sort)
+
+if [[ ${#tgz_files[@]} -eq 0 ]]; then
+    echo "[generate-npm-sbom] no .tgz files — nothing to embed"
+    exit 0
+fi
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+sbom_basename() {
+    # @calunga/foo → calunga-foo; plain name unchanged
+    local name="$1" version="$2"
+    local safe
+    safe="$(echo "${name}" | sed -e 's|^@||' -e 's|/|-|g')"
+    echo "${safe}-${version}.cdx.json"
+}
+
+npm_purl() {
+    local name="$1" version="$2"
+    if [[ "${name}" == @*/* ]]; then
+        local scope="${name%%/*}"
+        local unscoped="${name#*/}"
+        echo "pkg:npm/%40${scope#@}/${unscoped}@${version}"
+    else
+        echo "pkg:npm/${name}@${version}"
+    fi
+}
+
+embedded=0
+for tgz in "${tgz_files[@]}"; do
+    [[ -f "${tgz}" ]] || continue
+
+    rel="${tgz#${ARTIFACT_DIR}/}"
+    rel="${rel#/}"
+    extract_dir="${tmpdir}/extract-$((embedded))"
+    mkdir -p "${extract_dir}"
+
+    echo "[generate-npm-sbom] embedding SBOM into ${rel}"
+    tar -xzf "${tgz}" -C "${extract_dir}"
+
+    pkg_dir="${extract_dir}/package"
+    pkg_json="${pkg_dir}/package.json"
+    if [[ ! -f "${pkg_json}" ]]; then
+        echo "[generate-npm-sbom] ERROR: ${rel} missing package/package.json" >&2
+        exit 1
+    fi
+
+    name="$(jq -r '.name // empty' "${pkg_json}")"
+    version="$(jq -r '.version // empty' "${pkg_json}")"
+    if [[ -z "${name}" || -z "${version}" ]]; then
+        echo "[generate-npm-sbom] ERROR: ${rel} package.json missing name/version" >&2
+        exit 1
+    fi
+
+    sbom_file="$(sbom_basename "${name}" "${version}")"
+    sbom_rel="sboms/${sbom_file}"
+    mkdir -p "${pkg_dir}/sboms"
+    purl="$(npm_purl "${name}" "${version}")"
+
+    jq -n \
+        --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        --arg name "${name}" \
+        --arg version "${version}" \
+        --arg purl "${purl}" \
+        '{
+            bomFormat: "CycloneDX",
+            specVersion: "1.5",
+            version: 1,
+            metadata: {
+                timestamp: $ts,
+                tools: [{ vendor: "calunga", name: "generate-npm-sbom", version: "0.1" }],
+                component: {
+                    type: "library",
+                    name: $name,
+                    version: $version,
+                    purl: $purl
+                }
+            },
+            components: [
+                {
+                    type: "library",
+                    name: $name,
+                    version: $version,
+                    purl: $purl
+                }
+            ]
+        }' > "${pkg_dir}/${sbom_rel}"
+
+    # Ensure package.json files includes the SBOM path (npm pack / publish allowlist).
+    jq --arg sbom "${sbom_rel}" '
+        .files = ((.files // []) + [$sbom] | unique | sort)
+    ' "${pkg_json}" > "${pkg_json}.next"
+    mv "${pkg_json}.next" "${pkg_json}"
+
+    # Repack in place (npm-style package/ root).
+    pack_root="$(mktemp -d "${tmpdir}/pack.XXXXXX")"
+    mkdir -p "${pack_root}/package"
+    cp -a "${pkg_dir}/." "${pack_root}/package/"
+    tar --create --gzip --file "${tgz}" --directory "${pack_root}" package
+
+    echo "[generate-npm-sbom] embedded ${sbom_rel} in ${rel}"
+    embedded=$((embedded + 1))
+done
+
+echo "[generate-npm-sbom] embedded SBOM into ${embedded} tarball(s)"

--- a/tasks/build-npm-package-oci-ta.yaml
+++ b/tasks/build-npm-package-oci-ta.yaml
@@ -10,9 +10,10 @@ metadata:
     app.kubernetes.io/version: "0.1"
 spec:
   description: >-
-    Build npm Trusted Libraries packages from onboarding recipes and push
-    collected tarballs as an OCI artifact to Quay (mirrors build-python-wheels).
-    Optional Pulp Stage publish when PUBLISH_TO_PULP=true.
+    Build npm Trusted Libraries packages from onboarding recipes, generate a
+    CycloneDX SBOM, and push an OCI artifact to Quay (mirrors build-python-wheels:
+    SBOM at build; attestations at release). Optional Pulp Stage when
+    PUBLISH_TO_PULP=true.
   params:
     - name: PACKAGES
       description: >-
@@ -117,18 +118,19 @@ spec:
         requests:
           cpu: "1"
           memory: 512Mi
-    - name: embed-compliance
+    - name: generate-sbom
       image: $(params.BUILDER_IMAGE)
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
-        # Phase 1 stub: compliance metadata is computed in a later iteration.
-        echo "[embed-compliance] stub — tl-compliance.json / artifact.json not embedded yet"
+        ARTIFACT_ROOT="${ARTIFACT_ROOT:-${WORKDIR_ROOT}/artifact}"
+        # Embed CycloneDX into every collected .tgz (main + platform), like SPDX-in-wheel.
+        generate-npm-sbom "${ARTIFACT_ROOT}"
       computeResources:
         limits:
-          memory: 512Mi
+          memory: 1Gi
         requests:
-          cpu: "100m"
+          cpu: "250m"
           memory: 256Mi
     - name: create-oci-artifact
       image: quay.io/konflux-ci/oras:latest@sha256:1beeecce012c99794568f74265c065839f9703d28306a8430b667f639343a98b

--- a/utils/scripts/generate-and-sign-npm-attestations
+++ b/utils/scripts/generate-and-sign-npm-attestations
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Generate and sign SLSA provenance attestations for npm package tarballs.
+# Release-phase helper (mirrors generate-and-sign-attestations for wheels).
+# Production path will be a release-service-catalog task like rh-sign-python-wheels
+# using AWS KMS; this script is the shared/local implementation.
+#
+# Modeled after generate-and-sign-attestations and rh-sign-python-wheels
+# (AWS KMS + SLSA v1). Outputs cosign DSSE envelopes as <tarball>.att
+# (npm has no PEP 740 equivalent).
+#
+# Signing material (first match wins):
+#   1. COSIGN_KEY_PATH or /etc/cosign-secret/cosign.key  (local key file)
+#   2. /etc/cosign-secret/SIGN_KEY + AWS_*               (AWS KMS, release path)
+#
+# Env:
+#   FILES_DIR              Directory of collected .tgz (required)
+#   REQUIRE_ATTESTATIONS   If "true", fail when no signing material (default: false)
+#   BUILD_TYPE             SLSA buildType URI (default: NpmPackageBuild@v1)
+set -euo pipefail
+
+FILES_DIR="${FILES_DIR:?FILES_DIR required}"
+REQUIRE_ATTESTATIONS="${REQUIRE_ATTESTATIONS:-false}"
+BUILD_TYPE="${BUILD_TYPE:-https://konflux-ci.dev/NpmPackageBuild@v1}"
+BUILDER_ID="${BUILDER_ID:-https://konflux-ci.dev/calunga}"
+COSIGN_KEY_PATH="${COSIGN_KEY_PATH:-/etc/cosign-secret/cosign.key}"
+SECRET_DIR="${COSIGN_SECRET_DIR:-/etc/cosign-secret}"
+
+if [[ ! -d "${FILES_DIR}" ]]; then
+    echo "ERROR: FILES_DIR does not exist: ${FILES_DIR}" >&2
+    exit 1
+fi
+
+tgz_files=()
+while IFS= read -r f; do
+    [[ -n "${f}" ]] && tgz_files+=("$f")
+done < <(find "${FILES_DIR}" -type f -name '*.tgz' | LC_ALL=C sort)
+if [[ ${#tgz_files[@]} -eq 0 ]]; then
+    echo "[generate-and-sign-npm-attestations] no .tgz files — skipping"
+    exit 0
+fi
+
+if ! command -v cosign >/dev/null 2>&1; then
+    echo "Installing cosign..."
+    curl -sLO https://github.com/sigstore/cosign/releases/download/v2.2.4/cosign-linux-amd64
+    chmod +x cosign-linux-amd64
+    mv cosign-linux-amd64 /usr/local/bin/cosign
+fi
+
+echo "Cosign version:"
+cosign version
+
+SIGN_MODE=""
+declare -a COSIGN_KEY_ARGS=()
+declare -a REKOR_ARGS=("--tlog-upload=false")
+
+if [[ -f "${COSIGN_KEY_PATH}" ]]; then
+    SIGN_MODE="keyfile"
+    COSIGN_KEY_ARGS=(--key "${COSIGN_KEY_PATH}")
+    export COSIGN_PASSWORD="${COSIGN_PASSWORD:-}"
+elif [[ -f "${SECRET_DIR}/SIGN_KEY" ]]; then
+    SIGN_MODE="kms"
+    for key in AWS_DEFAULT_REGION AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY; do
+        if [[ -f "${SECRET_DIR}/${key}" ]]; then
+            export "${key}=$(cat "${SECRET_DIR}/${key}")"
+        fi
+    done
+    SIGN_KEY="$(cat "${SECRET_DIR}/SIGN_KEY")"
+    COSIGN_KEY_ARGS=(--key "${SIGN_KEY}")
+    if [[ -s "${SECRET_DIR}/REKOR_URL" ]]; then
+        REKOR_ARGS=(-y --rekor-url="$(cat "${SECRET_DIR}/REKOR_URL")")
+    fi
+fi
+
+if [[ -z "${SIGN_MODE}" ]]; then
+    msg="No cosign signing material at ${COSIGN_KEY_PATH} or ${SECRET_DIR}/SIGN_KEY"
+    if [[ "${REQUIRE_ATTESTATIONS}" == "true" ]]; then
+        echo "ERROR: ${msg}" >&2
+        exit 1
+    fi
+    echo "WARNING: ${msg} — skipping attestation (REQUIRE_ATTESTATIONS=${REQUIRE_ATTESTATIONS})"
+    exit 0
+fi
+
+echo "=== npm attestation generation (${SIGN_MODE}) ==="
+RELEASE_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "Timestamp: ${RELEASE_TIME}"
+echo "Files directory: ${FILES_DIR}"
+
+ATT_COUNT=0
+SIGNED_COUNT=0
+
+cd "${FILES_DIR}"
+ls -lah
+
+for TGZ in "${tgz_files[@]}"; do
+    [[ -f "${TGZ}" ]] || continue
+
+    rel="${TGZ#${FILES_DIR}/}"
+    rel="${rel#/}"
+
+    echo ""
+    echo "Processing: ${rel}"
+    TGZ_SHA256="$(sha256sum "${TGZ}" | cut -d' ' -f1)"
+    echo "  SHA256: ${TGZ_SHA256}"
+
+    PREDICATE_FILE="$(mktemp)"
+    jq -n \
+        --arg release_time "${RELEASE_TIME}" \
+        --arg build_type "${BUILD_TYPE}" \
+        --arg builder_id "${BUILDER_ID}" \
+        '{
+            buildDefinition: {
+                buildType: $build_type,
+                externalParameters: {},
+                resolvedDependencies: []
+            },
+            runDetails: {
+                builder: { id: $builder_id },
+                metadata: { finishedOn: $release_time }
+            }
+        }' > "${PREDICATE_FILE}"
+
+    ATT_FILE="${TGZ}.att"
+    DSSE_FILE="$(mktemp)"
+
+    echo "Signing attestation with cosign (${SIGN_MODE})"
+    if cosign attest-blob "${TGZ}" \
+        --predicate="${PREDICATE_FILE}" \
+        --type=https://slsa.dev/provenance/v1 \
+        "${COSIGN_KEY_ARGS[@]}" \
+        --yes \
+        "${REKOR_ARGS[@]}" \
+        --output-file="${DSSE_FILE}"
+    then
+        cp "${DSSE_FILE}" "${ATT_FILE}"
+        echo "Created DSSE attestation: ${ATT_FILE}"
+        SIGNED_COUNT=$((SIGNED_COUNT + 1))
+    else
+        echo "ERROR: Failed to sign attestation for ${TGZ}" >&2
+        rm -f "${PREDICATE_FILE}" "${DSSE_FILE}"
+        exit 1
+    fi
+
+    ATT_COUNT=$((ATT_COUNT + 1))
+    rm -f "${PREDICATE_FILE}" "${DSSE_FILE}"
+done
+
+echo ""
+echo "=========================================="
+echo "Attestation Generation Summary:"
+echo "  Total attestations: ${ATT_COUNT}"
+echo "  Signed (DSSE .att): ${SIGNED_COUNT}"
+echo "=========================================="
+ls -lah


### PR DESCRIPTION
Making sure npm builds embeds sbom files inside packages. Delaying attest and sign util release where the secrets are available. However, including the attest and sign script for npm modeled after python version. 

Assisted by Cursor 3.5.33

## Summary by Sourcery

Add SBOM generation to the npm package build pipeline and introduce release-phase npm attestation/signing utilities.

New Features:
- Generate and embed CycloneDX SBOMs into built npm package tarballs during the OCI artifact build task.
- Add a utility script to generate and sign npm attestations for npm packages, aligned with the existing Python workflow.

Enhancements:
- Document the new SBOM generation command and clarify that package attestations occur at release time rather than during the build.
- Include the SBOM generation script in the npm-builder container image and adjust Tekton task resources to support SBOM generation.