### PR TITLE
Extract inline Python from install-and-import-wheels…

### DIFF
--- a/.github/workflows/wheel-check-scripts.yml
+++ b/.github/workflows/wheel-check-scripts.yml
@@ -1,0 +1,32 @@
+name: Wheel Check Scripts
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'tasks/scripts/wheel-check/**.py'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+    - name: Set up Python
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+      with:
+        python-version: '3.12'
+
+    - name: Install pytest
+      run: pip install pytest
+
+    - name: Run tests
+      working-directory: tasks/scripts/wheel-check
+      run: python -m pytest test_*.py -v

--- a/tasks/install-and-import-wheels.yaml
+++ b/tasks/install-and-import-wheels.yaml
@@ -21,9 +21,7 @@ spec:
     - name: workdir
       emptyDir: {}
     - name: wheel-check-scripts
-      configMap:
-        name: wheel-check-scripts
-        defaultMode: 0755
+      emptyDir: {}
   stepTemplate:
     env:
       - name: SNAPSHOT
@@ -37,8 +35,32 @@ spec:
         mountPath: /var/workdir
       - name: wheel-check-scripts
         mountPath: /opt/wheel-check
-        readOnly: true
   steps:
+    - name: clone-scripts
+      image: quay.io/konflux-ci/task-runner:2.1.0@sha256:c34c933c269e2401bb042fe69e2999cf288331b6586d4f4eca9c845270d9b1f9
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        REPO="https://github.com/calungaproject/plumbing.git"
+        SCRIPTS_PATH="tasks/scripts/wheel-check"
+
+        cd /tmp
+        git clone --depth=1 --filter=blob:none --sparse "$REPO" plumbing
+        cd plumbing
+        git sparse-checkout set "$SCRIPTS_PATH"
+
+        for f in ${SCRIPTS_PATH}/*.py; do
+            case "$(basename "$f")" in test_*) continue;; esac
+            cp "$f" /opt/wheel-check/
+        done
+
+        echo "Cloned wheel-check scripts:"
+        ls -la /opt/wheel-check/
+
+        cd /tmp
+        rm -rf plumbing
+
     - name: get-image-urls
       image: quay.io/konflux-ci/task-runner:2.1.0@sha256:c34c933c269e2401bb042fe69e2999cf288331b6586d4f4eca9c845270d9b1f9
       script: |

--- a/tasks/install-and-import-wheels.yaml
+++ b/tasks/install-and-import-wheels.yaml
@@ -13,9 +13,17 @@ spec:
     - description: The image used for smoke testing the built wheels
       name: TEST_IMAGE
       type: string
+    - description: Python version to use for testing (e.g. 3.12, 3.13)
+      name: PYTHON_VERSION
+      type: string
+      default: "3.12"
   volumes:
     - name: workdir
       emptyDir: {}
+    - name: wheel-check-scripts
+      configMap:
+        name: wheel-check-scripts
+        defaultMode: 0755
   stepTemplate:
     env:
       - name: SNAPSHOT
@@ -27,6 +35,9 @@ spec:
     volumeMounts:
       - name: workdir
         mountPath: /var/workdir
+      - name: wheel-check-scripts
+        mountPath: /opt/wheel-check
+        readOnly: true
   steps:
     - name: get-image-urls
       image: quay.io/konflux-ci/task-runner:2.1.0@sha256:c34c933c269e2401bb042fe69e2999cf288331b6586d4f4eca9c845270d9b1f9
@@ -59,274 +70,19 @@ spec:
         #!/bin/bash
         set -euo pipefail
 
-        if command -v python3.12 >/dev/null 2>&1 && python3.12 -m venv --help >/dev/null 2>&1; then
-            echo "python3.12 and venv are already available, skipping installation"
+        PYTHON="python$(params.PYTHON_VERSION)"
+
+        if command -v "$PYTHON" >/dev/null 2>&1 && "$PYTHON" -m venv --help >/dev/null 2>&1; then
+            echo "$PYTHON and venv are already available, skipping installation"
         elif command -v dnf >/dev/null 2>&1; then
-            dnf install -y python3.12
+            dnf install -y "$PYTHON"
         elif command -v apt-get >/dev/null 2>&1; then
             export DEBIAN_FRONTEND=noninteractive
-            apt-get update && apt-get install -y python3.12 python3.12-venv
+            apt-get update && apt-get install -y "$PYTHON" "${PYTHON}-venv"
         else
-            echo "ERROR: No supported package manager found and python3.12 is not installed"
+            echo "ERROR: No supported package manager found and $PYTHON is not installed"
             exit 1
         fi
-
-        cat <<'EOF' > /tmp/verify_import.py
-        import importlib
-        import json
-        import sys
-        import zipfile
-        from collections import defaultdict
-        from pathlib import Path, PurePosixPath
-
-
-        def inspect_wheel(wheel_path):
-            """Open a .whl as a zip and extract metadata for classification and import detection."""
-            with zipfile.ZipFile(wheel_path) as zf:
-                entries = zf.namelist()
-
-                dist_info_dir = None
-                for entry in entries:
-                    parts = PurePosixPath(entry).parts
-                    if parts and parts[0].endswith('.dist-info'):
-                        dist_info_dir = parts[0]
-                        break
-
-                top_level_txt = None
-                if dist_info_dir:
-                    tl_path = f"{dist_info_dir}/top_level.txt"
-                    if tl_path in entries:
-                        top_level_txt = zf.read(tl_path).decode('utf-8', errors='replace')
-
-                content_entries = []
-                for entry in entries:
-                    parts = PurePosixPath(entry).parts
-                    if not parts:
-                        continue
-                    if parts[0].endswith(('.dist-info', '.data')):
-                        continue
-                    if entry.endswith('/'):
-                        continue
-                    content_entries.append(entry)
-
-                source_exts = {'.py', '.so', '.pyd'}
-                has_source = any(
-                    PurePosixPath(e).suffix in source_exts or '.cpython-' in PurePosixPath(e).name
-                    for e in content_entries
-                )
-
-            return {
-                'dist_info_dir': dist_info_dir,
-                'content_entries': content_entries,
-                'top_level_txt': top_level_txt,
-                'has_source': has_source,
-            }
-
-
-        def parse_dist_info(dist_info_dir):
-            """Extract (dist_name, version) from a .dist-info directory name."""
-            base = dist_info_dir.removesuffix('.dist-info')
-            parts = base.split('-', 1)
-            if len(parts) == 2:
-                return parts[0].replace('_', '-').lower(), parts[1]
-            return base.replace('_', '-').lower(), 'unknown'
-
-
-        def classify_wheel(inspection):
-            """Return 'empty', 'data-only', or 'importable' based on wheel contents."""
-            if not inspection['content_entries']:
-                return 'empty'
-            if not inspection['has_source']:
-                return 'data-only'
-            return 'importable'
-
-
-        def detect_import_names(inspection):
-            """Determine importable module names from wheel zip entries.
-
-            Scans for regular packages (__init__.py), namespace packages,
-            top-level modules, and extension modules. Uses top_level.txt as
-            a supplementary hint only, validated against actual wheel contents.
-            """
-            content_entries = inspection['content_entries']
-
-            top_level_dirs = defaultdict(list)
-            top_level_files = []
-
-            for entry in content_entries:
-                parts = PurePosixPath(entry).parts
-                if not parts:
-                    continue
-                if len(parts) == 1:
-                    top_level_files.append(parts[0])
-                else:
-                    top_level_dirs[parts[0]].append(entry)
-
-            import_names = set()
-            namespace_imports = set()
-
-            for dir_name, files in top_level_dirs.items():
-                has_init = any(
-                    PurePosixPath(f).parts == (dir_name, '__init__.py')
-                    for f in files
-                )
-                if has_init:
-                    import_names.add(dir_name)
-
-            for dir_name, files in top_level_dirs.items():
-                if dir_name in import_names:
-                    continue
-                has_py = any(
-                    PurePosixPath(f).suffix in ('.py', '.so', '.pyd')
-                    or '.cpython-' in PurePosixPath(f).name
-                    for f in files
-                )
-                if has_py:
-                    for f in files:
-                        fp = PurePosixPath(f)
-                        if fp.name == '__init__.py' and len(fp.parts) >= 2:
-                            dotted = '.'.join(fp.parts[:-1])
-                            namespace_imports.add(dotted)
-                    if not any(ni.startswith(dir_name + '.') for ni in namespace_imports):
-                        import_names.add(dir_name)
-
-            filtered_ns = set()
-            for ni in sorted(namespace_imports, key=lambda x: x.count('.')):
-                parts = ni.split('.')
-                if not any('.'.join(parts[:i]) in filtered_ns for i in range(1, len(parts))):
-                    filtered_ns.add(ni)
-            namespace_imports = filtered_ns
-
-            for f in top_level_files:
-                if f.endswith('.py'):
-                    import_names.add(Path(f).stem)
-
-            for f in top_level_files:
-                if f.endswith('.so') or f.endswith('.pyd') or '.cpython-' in f:
-                    import_names.add(f.split('.')[0])
-
-            import_names.update(namespace_imports)
-
-            non_underscore = {
-                name for name in import_names
-                if not any(part.startswith('_') for part in name.split('.'))
-                and name != 'tests'
-                and not name.endswith('.libs')
-                and not name.startswith('pytest_')
-            }
-            if non_underscore:
-                import_names = non_underscore
-            else:
-                import_names = {
-                    name for name in import_names
-                    if name != 'tests'
-                    and not name.endswith('.libs')
-                }
-
-            if inspection['top_level_txt']:
-                all_top_dirs = set(top_level_dirs.keys())
-                all_top_files = {Path(f).stem for f in top_level_files if f.endswith('.py')}
-                all_top_files.update(
-                    f.split('.')[0] for f in top_level_files
-                    if f.endswith('.so') or f.endswith('.pyd') or '.cpython-' in f
-                )
-                known_names = all_top_dirs | all_top_files
-
-                for line in inspection['top_level_txt'].splitlines():
-                    tl_name = line.strip()
-                    if not tl_name:
-                        continue
-                    if '/' in tl_name or '\\' in tl_name:
-                        continue
-                    if tl_name == 'tests':
-                        continue
-                    if tl_name.startswith('_') and import_names:
-                        continue
-                    if tl_name in known_names and tl_name not in import_names:
-                        import_names.add(tl_name)
-
-            return import_names
-
-
-        def check_import(name):
-            """Try to import a module by name; return (success, message)."""
-            try:
-                importlib.import_module(name)
-                return True, f"Successfully imported {name}"
-            except ImportError as e:
-                return False, f"ImportError: {e}"
-            except Exception as e:
-                return False, f"{type(e).__name__}: {e}"
-
-
-        def main():
-            """Classify a wheel and verify its imports; output a single JSON result line."""
-            classify_only = '--classify-only' in sys.argv
-            args = [a for a in sys.argv[1:] if a != '--classify-only']
-
-            if len(args) != 1:
-                print(json.dumps({"status": "ERROR", "reason": "Usage: verify_import.py [--classify-only] <wheel>"}))
-                sys.exit(2)
-
-            wheel_path = Path(args[0])
-            if not wheel_path.exists():
-                print(json.dumps({"wheel": wheel_path.name, "status": "ERROR",
-                                  "reason": f"File not found: {wheel_path}"}))
-                sys.exit(2)
-
-            inspection = inspect_wheel(wheel_path)
-
-            dist_name, version = 'unknown', 'unknown'
-            if inspection['dist_info_dir']:
-                dist_name, version = parse_dist_info(inspection['dist_info_dir'])
-
-            category = classify_wheel(inspection)
-
-            if category == 'empty':
-                print(json.dumps({"wheel": wheel_path.name, "dist_name": dist_name,
-                                  "version": version, "status": "SKIP",
-                                  "reason": "empty wheel (only dist-info, no source files)",
-                                  "imports_tested": []}))
-                sys.exit(0)
-
-            if category == 'data-only':
-                print(json.dumps({"wheel": wheel_path.name, "dist_name": dist_name,
-                                  "version": version, "status": "SKIP",
-                                  "reason": "data-only package (no importable Python code)",
-                                  "imports_tested": []}))
-                sys.exit(0)
-
-            if classify_only:
-                sys.exit(10)
-
-            import_names = detect_import_names(inspection)
-
-            if not import_names:
-                print(json.dumps({"wheel": wheel_path.name, "dist_name": dist_name,
-                                  "version": version, "status": "FAIL",
-                                  "reason": "has source files but could not determine import names",
-                                  "imports_tested": []}))
-                sys.exit(1)
-
-            results = []
-            any_failed = False
-            for name in sorted(import_names):
-                success, message = check_import(name)
-                results.append({"name": name, "success": success, "message": message})
-                if not success:
-                    any_failed = True
-
-            status = "FAIL" if any_failed else "PASS"
-            print(json.dumps({"wheel": wheel_path.name, "dist_name": dist_name,
-                              "version": version, "status": status,
-                              "reason": "import failures" if any_failed else "",
-                              "imports_tested": results}))
-            sys.exit(1 if any_failed else 0)
-
-
-        if __name__ == '__main__':
-            main()
-        EOF
 
         echo "Changing directory to ${FILES_DIR}"
         cd "${FILES_DIR}"
@@ -342,69 +98,10 @@ spec:
         RESULTS_DIR="/tmp/wheel-test-results"
         mkdir -p "${RESULTS_DIR}"
 
-        # Build a wheel index: normalized_name-version -> wheel filename
-        python3.12 -c "
-        import json, os, re
+        $PYTHON /opt/wheel-check/build_wheel_index.py .
+        $PYTHON /opt/wheel-check/detect_built_wheels.py .
 
-        def normalize(name):
-            return re.sub(r'[-_.]+', '_', name).lower()
-
-        wheel_index = {}
-        for f in os.listdir('.'):
-            if not f.endswith('.whl'):
-                continue
-            parts = f.split('-')
-            if len(parts) >= 2:
-                key = normalize(parts[0]) + '-' + parts[1]
-                wheel_index[key] = f
-
-        json.dump(wheel_index, open('/tmp/wheel-index.json', 'w'))
-        print(f'Indexed {len(wheel_index)} wheel(s)')
-        "
-
-        # Identify wheels built from source by checking for sdist presence.
-        # Fromager bootstrap only creates sdists for packages it builds from
-        # source — packages found on the cache wheel server are downloaded as
-        # wheels directly. Three outcomes:
-        #   - no_sdists: no .tar.gz files — test everything (backward compat)
-        #   - all_cached: wheels present but no sdists — skip all tests
-        #   - has_built: sdists found — test only matching wheels
-        python3.12 -c "
-        import json, os, re
-
-        def normalize(name):
-            return re.sub(r'[-_.]+', '_', name).lower()
-
-        sdist_pkgs = set()
-        for f in os.listdir('.'):
-            if not f.endswith('.tar.gz'):
-                continue
-            base = f[:-len('.tar.gz')]
-            name_part, _, version_part = base.rpartition('-')
-            if name_part:
-                sdist_pkgs.add(normalize(name_part))
-
-        wheel_index = json.load(open('/tmp/wheel-index.json'))
-        built = set()
-        for key, whl in wheel_index.items():
-            pkg_name = normalize(key.rsplit('-', 1)[0])
-            if pkg_name in sdist_pkgs:
-                built.add(whl)
-
-        if sdist_pkgs and built:
-            status = 'has_built'
-            print(f'Found {len(sdist_pkgs)} sdist(s), matched {len(built)} wheel(s) built from source')
-        elif len(wheel_index) > 0 and not sdist_pkgs:
-            status = 'all_cached'
-            print(f'All {len(wheel_index)} wheel(s) pulled from cache — no sdists found')
-        else:
-            status = 'no_sdists'
-            print('No sdists found — will test all wheels')
-
-        json.dump({'status': status, 'wheels': list(built)}, open('/tmp/built-wheels.json', 'w'))
-        "
-
-        BUILT_WHEELS_STATUS=$(python3.12 -c "import json; print(json.load(open('/tmp/built-wheels.json'))['status'])" 2>/dev/null || echo "no_sdists")
+        BUILT_WHEELS_STATUS=$($PYTHON /opt/wheel-check/wheel_helpers.py read-built-status 2>/dev/null || echo "no_sdists")
 
         if [ "$BUILT_WHEELS_STATUS" = "all_cached" ]; then
             echo ""
@@ -417,7 +114,7 @@ spec:
 
         BUILT_WHEELS_SET=""
         if [ "$BUILT_WHEELS_STATUS" = "has_built" ]; then
-            BUILT_WHEELS_SET=$(python3.12 -c "import json; print(','.join(json.load(open('/tmp/built-wheels.json'))['wheels']))")
+            BUILT_WHEELS_SET=$($PYTHON /opt/wheel-check/wheel_helpers.py read-built-wheels)
         fi
 
         # Phase 1: Test each wheel in its own isolated venv.
@@ -434,7 +131,7 @@ spec:
                     echo "=================================================="
                     echo "SKIP (no sdist, cached): $WHEEL"
                     RESULT_FILE="${RESULTS_DIR}/$(echo "$WHEEL" | tr '/' '_').json"
-                    python3.12 -c "import json,sys; print(json.dumps({'wheel':sys.argv[1],'status':'SKIP','reason':'no matching sdist (not built from source)','imports_tested':[]}))" "$WHEEL" > "$RESULT_FILE"
+                    $PYTHON /opt/wheel-check/wheel_helpers.py write-skip "$WHEEL" "no matching sdist (not built from source)" > "$RESULT_FILE"
                     continue
                 fi
             fi
@@ -444,7 +141,7 @@ spec:
 
             RESULT_FILE="${RESULTS_DIR}/$(echo "$WHEEL" | tr '/' '_').json"
 
-            if python3.12 /tmp/verify_import.py --classify-only "${WHEEL}" > "$RESULT_FILE"; then
+            if $PYTHON /opt/wheel-check/verify_import.py --classify-only "${WHEEL}" > "$RESULT_FILE"; then
                 echo "SKIP: $WHEEL"
                 continue
             fi
@@ -453,18 +150,18 @@ spec:
 
             rm -rf /tmp/test-venv
             echo "Setting up virtual environment..."
-            python3.12 -m venv /tmp/test-venv
+            $PYTHON -m venv /tmp/test-venv
 
             echo "Installing wheel..."
             if ! /tmp/test-venv/bin/pip install --no-index --find-links . "${WHEEL}" 2>&1; then
                 echo "FAIL: Installation failed for $WHEEL"
-                python3.12 -c "import json,sys; print(json.dumps({'wheel':sys.argv[1],'status':'FAIL','reason':'pip install failed','imports_tested':[]}))" "$WHEEL" > "$RESULT_FILE"
+                $PYTHON /opt/wheel-check/wheel_helpers.py write-failure "$WHEEL" "pip install failed" > "$RESULT_FILE"
                 INDIVIDUAL_FAILED=true
                 continue
             fi
 
             echo "Verifying import..."
-            if /tmp/test-venv/bin/python /tmp/verify_import.py "${WHEEL}" > "$RESULT_FILE"; then
+            if /tmp/test-venv/bin/python /opt/wheel-check/verify_import.py "${WHEEL}" > "$RESULT_FILE"; then
                 echo "PASS: $WHEEL"
             else
                 VERIFY_RC=$?
@@ -472,26 +169,13 @@ spec:
                     echo "ERROR: Script error for $WHEEL"
                     INDIVIDUAL_FAILED=true
                 else
-                    STATUS=$(python3.12 -c "import json,sys; print(json.load(open(sys.argv[1])).get('status','FAIL'))" "$RESULT_FILE" 2>/dev/null || echo "FAIL")
+                    STATUS=$($PYTHON /opt/wheel-check/wheel_helpers.py read-status "$RESULT_FILE" 2>/dev/null || echo "FAIL")
                     if [ "$STATUS" = "SKIP" ]; then
                         echo "SKIP: $WHEEL"
                     else
                         echo "FAIL: $WHEEL"
                         INDIVIDUAL_FAILED=true
-                        python3.12 -c "
-        import json, sys
-        try:
-            with open(sys.argv[1]) as f:
-                d = json.load(f)
-            for t in d.get('imports_tested', []):
-                if not isinstance(t, dict) or t.get('success'):
-                    continue
-                name = t.get('name', '<unknown>')
-                message = t.get('message', '')
-                print(f'  {name}: {message}')
-        except Exception:
-            pass
-        " "$RESULT_FILE"
+                        $PYTHON /opt/wheel-check/wheel_helpers.py print-failures "$RESULT_FILE" --prefix "  "
                     fi
                 fi
             fi
@@ -512,17 +196,7 @@ spec:
 
         for RESULT_FILE in "${RESULTS_DIR}"/*.json; do
             [ -f "$RESULT_FILE" ] || continue
-            ROW=$(python3.12 -c "
-        import json, sys
-        try:
-            d = json.load(open(sys.argv[1]))
-            w = d.get('wheel','?')
-            s = d.get('status','ERROR')
-            r = d.get('reason','')
-        except Exception:
-            w, s, r = '?', 'ERROR', 'parse error'
-        print(f'{s}\t{w}\t{r}')
-        " "$RESULT_FILE" 2>/dev/null)
+            ROW=$($PYTHON /opt/wheel-check/wheel_helpers.py format-row "$RESULT_FILE" 2>/dev/null)
 
             R_STATUS="${ROW%%	*}"
             REST="${ROW#*	}"
@@ -532,20 +206,7 @@ spec:
             printf "%-60s %-8s %s\n" "$R_WHEEL" "$R_STATUS" "$R_REASON"
 
             if [ "$R_STATUS" = "FAIL" ]; then
-                python3.12 -c "
-        import json, sys
-        try:
-            with open(sys.argv[1]) as f:
-                d = json.load(f)
-            for t in d.get('imports_tested', []):
-                if not isinstance(t, dict) or t.get('success'):
-                    continue
-                name = t.get('name', '<unknown>')
-                message = t.get('message', '')
-                print(f'  -> {name}: {message}')
-        except Exception:
-            pass
-        " "$RESULT_FILE"
+                $PYTHON /opt/wheel-check/wheel_helpers.py print-failures "$RESULT_FILE" --prefix "  -> "
             fi
 
             case "$R_STATUS" in
@@ -587,50 +248,7 @@ spec:
 
         echo "Found ${#SUMMARY_FILES[@]} build-sequence-summary file(s)"
 
-        # Build reverse mapping: import name -> wheel filename(s).
-        # Handles cases where import name != distribution name
-        # (e.g. bs4 -> beautifulsoup4, PIL -> pillow).
-        python3.12 -c "
-        import json, os, re, zipfile
-        from pathlib import PurePosixPath
-
-        def normalize(name):
-            return re.sub(r'[-_.]+', '_', name).lower()
-
-        import_to_wheel = {}
-        for f in sorted(os.listdir('.')):
-            if not f.endswith('.whl'):
-                continue
-            try:
-                names = set()
-                with zipfile.ZipFile(f) as zf:
-                    entries = zf.namelist()
-                    # Try top_level.txt first
-                    for entry in entries:
-                        if entry.endswith('/top_level.txt'):
-                            for line in zf.read(entry).decode('utf-8', errors='replace').splitlines():
-                                n = line.strip()
-                                if n and not n.startswith('#'):
-                                    names.add(n)
-                            break
-                    # Fall back to scanning directory structure
-                    if not names:
-                        for entry in entries:
-                            parts = PurePosixPath(entry).parts
-                            if not parts or parts[0].endswith(('.dist-info', '.data')):
-                                continue
-                            if len(parts) >= 2 and parts[1] == '__init__.py':
-                                names.add(parts[0])
-                            elif len(parts) == 1 and entry.endswith('.py'):
-                                names.add(PurePosixPath(entry).stem)
-                for n in names:
-                    import_to_wheel.setdefault(normalize(n), []).append(f)
-            except Exception:
-                pass
-
-        json.dump(import_to_wheel, open('/tmp/import-to-wheel.json', 'w'))
-        print(f'Mapped {len(import_to_wheel)} import name(s) to wheels')
-        "
+        $PYTHON /opt/wheel-check/build_import_map.py .
         COMBINED_RESULTS_DIR="/tmp/wheel-test-results-combined"
         rm -rf "${COMBINED_RESULTS_DIR}"
         mkdir -p "${COMBINED_RESULTS_DIR}"
@@ -654,20 +272,7 @@ spec:
             echo "Group ${GROUP_INDEX}: ${PRIMARY_LABEL}"
             echo "=================================================="
 
-            PRIMARY_INFO=$(python3.12 -c "
-        import json, re, sys
-        label = re.sub(r'[-.]', '_', sys.argv[1]).lower()
-        wheel_index = json.load(open('/tmp/wheel-index.json'))
-        for entry in json.load(open(sys.argv[2])):
-            norm = re.sub(r'[-_.]+', '_', entry['name']).lower()
-            if label.startswith(norm + '__'):
-                name = entry['name']
-                version = entry['version']
-                key = norm + '-' + version
-                wheel = wheel_index.get(key, '')
-                print(f'{name}\n{version}\n{wheel}')
-                break
-        " "$PRIMARY_LABEL" "$SUMMARY_FILE")
+            PRIMARY_INFO=$($PYTHON /opt/wheel-check/wheel_helpers.py lookup-primary "$PRIMARY_LABEL" "$SUMMARY_FILE" /tmp/wheel-index.json)
             PRIMARY_NAME=$(echo "$PRIMARY_INFO" | sed -n '1p')
             PRIMARY_VERSION=$(echo "$PRIMARY_INFO" | sed -n '2p')
             PRIMARY_WHEEL=$(echo "$PRIMARY_INFO" | sed -n '3p')
@@ -678,24 +283,7 @@ spec:
 
             # Skip entire group if no wheel in the group has a matching sdist
             if [ -n "$BUILT_WHEELS_SET" ]; then
-                GROUP_HAS_BUILT=$(python3.12 -c "
-        import json, re, sys
-        def normalize(name):
-            return re.sub(r'[-_.]+', '_', name).lower()
-        built = set(sys.argv[2].split(','))
-        try:
-            entries = json.load(open(sys.argv[1]))
-            wheel_index = json.load(open('/tmp/wheel-index.json'))
-            for e in entries:
-                if not isinstance(e, dict): continue
-                key = normalize(e.get('name','')) + '-' + str(e.get('version',''))
-                whl = wheel_index.get(key, '')
-                if whl in built:
-                    print('yes'); sys.exit()
-        except Exception as exc:
-            print(f'WARNING: {exc}', file=sys.stderr)
-        print('no')
-        " "$SUMMARY_FILE" "$BUILT_WHEELS_SET")
+                GROUP_HAS_BUILT=$($PYTHON /opt/wheel-check/wheel_helpers.py group-has-built "$SUMMARY_FILE" "$BUILT_WHEELS_SET")
                 if [ "$GROUP_HAS_BUILT" = "no" ]; then
                     echo "  SKIP group (no wheels with sdist match)"
                     continue
@@ -704,25 +292,14 @@ spec:
 
             echo "  Installing ${PRIMARY_NAME}==${PRIMARY_VERSION}..."
             rm -rf /tmp/test-venv-group
-            python3.12 -m venv /tmp/test-venv-group
+            $PYTHON -m venv /tmp/test-venv-group
             if ! /tmp/test-venv-group/bin/pip install --no-index --find-links . "${PRIMARY_NAME}==${PRIMARY_VERSION}" 2>&1; then
                 echo "  WARNING: Group install failed for ${PRIMARY_LABEL}, skipping"
                 continue
             fi
 
             # Get installed packages and match to wheel files in artifact
-            readarray -t INSTALLED_WHEELS < <(/tmp/test-venv-group/bin/pip list --format=json 2>/dev/null | python3.12 -c "
-        import json, re, sys
-        def normalize(name):
-            return re.sub(r'[-_.]+', '_', name).lower()
-        wheel_index = json.load(open('/tmp/wheel-index.json'))
-        installed = json.load(sys.stdin)
-        for pkg in installed:
-            key = normalize(pkg['name']) + '-' + pkg['version']
-            whl = wheel_index.get(key)
-            if whl:
-                print(whl)
-        ")
+            readarray -t INSTALLED_WHEELS < <(/tmp/test-venv-group/bin/pip list --format=json 2>/dev/null | $PYTHON /opt/wheel-check/wheel_helpers.py match-installed /tmp/wheel-index.json)
 
             GROUP_FAILED=false
             TESTED_IN_GROUP=" "
@@ -741,14 +318,14 @@ spec:
 
                 # Skip non-importable wheels already classified in phase 1
                 if [ -f "$RESULT_FILE" ]; then
-                    PREV_STATUS=$(python3.12 -c "import json,sys; print(json.load(open(sys.argv[1])).get('status',''))" "$RESULT_FILE" 2>/dev/null || true)
+                    PREV_STATUS=$($PYTHON /opt/wheel-check/wheel_helpers.py read-status "$RESULT_FILE" 2>/dev/null || true)
                     if [ "$PREV_STATUS" = "SKIP" ]; then
                         continue
                     fi
                 fi
 
                 # Classify: skip non-importable wheels
-                if python3.12 /tmp/verify_import.py --classify-only "${WHEEL}" > /dev/null 2>&1; then
+                if $PYTHON /opt/wheel-check/verify_import.py --classify-only "${WHEEL}" > /dev/null 2>&1; then
                     continue
                 fi
 
@@ -759,20 +336,13 @@ spec:
 
                 echo "  Testing import (group ${GROUP_INDEX}): $WHEEL..."
 
-                PREV_UNDECLARED=$(python3.12 -c "import json,sys; print(json.load(open(sys.argv[1])).get('undeclared_dep',''))" "$RESULT_FILE" 2>/dev/null || true)
+                PREV_UNDECLARED=$($PYTHON /opt/wheel-check/wheel_helpers.py read-field "$RESULT_FILE" undeclared_dep 2>/dev/null || true)
 
-                if /tmp/test-venv-group/bin/python /tmp/verify_import.py "${WHEEL}" > "$RESULT_FILE"; then
+                if /tmp/test-venv-group/bin/python /opt/wheel-check/verify_import.py "${WHEEL}" > "$RESULT_FILE"; then
                     echo "  PASS: $WHEEL"
                     TESTED_IN_GROUP="${TESTED_IN_GROUP}${WHEEL} "
                     if [ -n "$PREV_UNDECLARED" ]; then
-                        python3.12 -c "
-        import json, sys
-        with open(sys.argv[1]) as f:
-            d = json.load(f)
-        d['undeclared_dep'] = sys.argv[2]
-        with open(sys.argv[1], 'w') as f:
-            json.dump(d, f)
-        " "$RESULT_FILE" "$PREV_UNDECLARED"
+                        $PYTHON /opt/wheel-check/wheel_helpers.py annotate-dep "$RESULT_FILE" "$PREV_UNDECLARED"
                     fi
                 else
                     VERIFY_RC=$?
@@ -782,7 +352,7 @@ spec:
                         continue
                     fi
 
-                    STATUS=$(python3.12 -c "import json,sys; print(json.load(open(sys.argv[1])).get('status','FAIL'))" "$RESULT_FILE" 2>/dev/null || echo "FAIL")
+                    STATUS=$($PYTHON /opt/wheel-check/wheel_helpers.py read-status "$RESULT_FILE" 2>/dev/null || echo "FAIL")
                     if [ "$STATUS" = "SKIP" ]; then
                         echo "  SKIP: $WHEEL"
                         continue
@@ -797,44 +367,13 @@ spec:
                     FOUND_DEPS=""
                     FALLBACK_RESOLVED=false
                     while true; do
-                        MISSING_MODULE=$(python3.12 -c "
-        import json, sys
-        d = json.load(open(sys.argv[1]))
-        for t in d.get('imports_tested', []):
-            if isinstance(t, dict) and not t.get('success', True):
-                msg = t.get('message', '')
-                if 'No module named' in msg:
-                    mod = msg.split(\"'\")[1] if \"'\" in msg else ''
-                    if mod:
-                        print(mod.split('.')[0])
-                        break
-        " "$RESULT_FILE" 2>/dev/null || true)
+                        MISSING_MODULE=$($PYTHON /opt/wheel-check/wheel_helpers.py extract-missing "$RESULT_FILE" 2>/dev/null || true)
 
                         if [ -z "$MISSING_MODULE" ]; then
                             break
                         fi
 
-                        MISSING_WHEEL=$(python3.12 -c "
-        import re, sys, os, json
-        def normalize(name):
-            return re.sub(r'[-_.]+', '_', name).lower()
-        target = normalize(sys.argv[1])
-        tried = set(sys.argv[2].split(',')) if sys.argv[2] else set()
-        # Check import-to-wheel mapping first (handles import != dist name)
-        try:
-            import_map = json.load(open('/tmp/import-to-wheel.json'))
-            for whl in import_map.get(target, []):
-                if whl not in tried:
-                    print(whl)
-                    sys.exit(0)
-        except Exception:
-            pass
-        # Fallback: match by distribution name
-        for f in sorted(os.listdir('.')):
-            if f.endswith('.whl') and normalize(f.split('-')[0]) == target and f not in tried:
-                print(f)
-                break
-        " "$MISSING_MODULE" "$TRIED_WHEELS" 2>/dev/null || true)
+                        MISSING_WHEEL=$($PYTHON /opt/wheel-check/wheel_helpers.py find-missing "$MISSING_MODULE" "$TRIED_WHEELS" /tmp/import-to-wheel.json 2>/dev/null || true)
 
                         if [ -z "$MISSING_WHEEL" ]; then
                             break
@@ -847,7 +386,7 @@ spec:
                         # so pip can resolve all constraints holistically
                         echo "  Retrying with undeclared dep(s): ${FOUND_DEPS}"
                         rm -rf /tmp/test-venv-group
-                        python3.12 -m venv /tmp/test-venv-group
+                        $PYTHON -m venv /tmp/test-venv-group
                         if ! /tmp/test-venv-group/bin/pip install --no-index --find-links . \
                             "${PRIMARY_NAME}==${PRIMARY_VERSION}" ${FOUND_DEPS} 2>&1; then
                             echo "  WARNING: Install failed with deps: ${FOUND_DEPS}"
@@ -855,30 +394,12 @@ spec:
                         fi
 
                         # Refresh installed wheels list from clean install
-                        readarray -t INSTALLED_WHEELS < <(/tmp/test-venv-group/bin/pip list --format=json 2>/dev/null | python3.12 -c "
-        import json, re, sys
-        def normalize(name):
-            return re.sub(r'[-_.]+', '_', name).lower()
-        wheel_index = json.load(open('/tmp/wheel-index.json'))
-        installed = json.load(sys.stdin)
-        for pkg in installed:
-            key = normalize(pkg['name']) + '-' + pkg['version']
-            whl = wheel_index.get(key)
-            if whl:
-                print(whl)
-        ")
+                        readarray -t INSTALLED_WHEELS < <(/tmp/test-venv-group/bin/pip list --format=json 2>/dev/null | $PYTHON /opt/wheel-check/wheel_helpers.py match-installed /tmp/wheel-index.json)
                         WHEEL_IDX=0
 
-                        if /tmp/test-venv-group/bin/python /tmp/verify_import.py "${WHEEL}" > "$RESULT_FILE"; then
+                        if /tmp/test-venv-group/bin/python /opt/wheel-check/verify_import.py "${WHEEL}" > "$RESULT_FILE"; then
                             echo "  PASS: $WHEEL (with undeclared deps: ${UNDECLARED_DEPS})"
-                            python3.12 -c "
-        import json, sys
-        with open(sys.argv[1]) as f:
-            d = json.load(f)
-        d['undeclared_dep'] = sys.argv[2]
-        with open(sys.argv[1], 'w') as f:
-            json.dump(d, f)
-        " "$RESULT_FILE" "$UNDECLARED_DEPS"
+                            $PYTHON /opt/wheel-check/wheel_helpers.py annotate-dep "$RESULT_FILE" "$UNDECLARED_DEPS"
                             TESTED_IN_GROUP="${TESTED_IN_GROUP}${WHEEL} "
                             FALLBACK_RESOLVED=true
                             break
@@ -896,7 +417,7 @@ spec:
 
                     # Restore group venv so remaining wheels aren't poisoned
                     rm -rf /tmp/test-venv-group
-                    python3.12 -m venv /tmp/test-venv-group
+                    $PYTHON -m venv /tmp/test-venv-group
                     if ! /tmp/test-venv-group/bin/pip install --no-index --find-links . \
                         "${PRIMARY_NAME}==${PRIMARY_VERSION}" 2>&1; then
                         echo "  WARNING: Could not restore group venv for ${PRIMARY_LABEL}, skipping remaining wheels"
@@ -905,20 +426,7 @@ spec:
 
                     echo "  FAIL: $WHEEL"
                     GROUP_FAILED=true
-                    python3.12 -c "
-        import json, sys
-        try:
-            with open(sys.argv[1]) as f:
-                d = json.load(f)
-            for t in d.get('imports_tested', []):
-                if not isinstance(t, dict) or t.get('success'):
-                    continue
-                name = t.get('name', '<unknown>')
-                message = t.get('message', '')
-                print(f'    -> {name}: {message}')
-        except Exception:
-            pass
-        " "$RESULT_FILE"
+                    $PYTHON /opt/wheel-check/wheel_helpers.py print-failures "$RESULT_FILE" --prefix "    -> "
                 fi
             done
 
@@ -942,20 +450,7 @@ spec:
 
         for RESULT_FILE in "${COMBINED_RESULTS_DIR}"/*.json; do
             [ -f "$RESULT_FILE" ] || continue
-            ROW=$(python3.12 -c "
-        import json, sys
-        try:
-            d = json.load(open(sys.argv[1]))
-            w = d.get('wheel','?')
-            s = d.get('status','ERROR')
-            r = d.get('reason','')
-            dep = d.get('undeclared_dep','')
-            if dep:
-                r = f'undeclared dep: {dep}' if not r else f'{r} (undeclared dep: {dep})'
-        except Exception:
-            w, s, r = '?', 'ERROR', 'parse error'
-        print(f'{s}\t{w}\t{r}')
-        " "$RESULT_FILE" 2>/dev/null)
+            ROW=$($PYTHON /opt/wheel-check/wheel_helpers.py format-row "$RESULT_FILE" 2>/dev/null)
 
             R_STATUS="${ROW%%	*}"
             REST="${ROW#*	}"
@@ -965,20 +460,7 @@ spec:
             printf "%-60s %-8s %s\n" "$R_WHEEL" "$R_STATUS" "$R_REASON"
 
             if [ "$R_STATUS" = "FAIL" ]; then
-                python3.12 -c "
-        import json, sys
-        try:
-            with open(sys.argv[1]) as f:
-                d = json.load(f)
-            for t in d.get('imports_tested', []):
-                if not isinstance(t, dict) or t.get('success'):
-                    continue
-                name = t.get('name', '<unknown>')
-                message = t.get('message', '')
-                print(f'  -> {name}: {message}')
-        except Exception:
-            pass
-        " "$RESULT_FILE"
+                $PYTHON /opt/wheel-check/wheel_helpers.py print-failures "$RESULT_FILE" --prefix "  -> "
             fi
 
             case "$R_STATUS" in

--- a/tasks/scripts/wheel-check/build_import_map.py
+++ b/tasks/scripts/wheel-check/build_import_map.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from wheel_helpers import normalize
+from verify_import import inspect_wheel, detect_import_names
+
+
+def main(wheels_dir=None, output_path='/tmp/import-to-wheel.json'):
+    if wheels_dir is None:
+        wheels_dir = sys.argv[1] if len(sys.argv) > 1 else '.'
+    import_to_wheel = {}
+    for f in sorted(os.listdir(wheels_dir)):
+        if not f.endswith('.whl'):
+            continue
+        whl_path = os.path.join(wheels_dir, f) if wheels_dir != '.' else f
+        try:
+            inspection = inspect_wheel(whl_path)
+            names = detect_import_names(inspection)
+            for n in names:
+                import_to_wheel.setdefault(normalize(n), []).append(f)
+        except Exception:
+            pass
+    json.dump(import_to_wheel, open(output_path, 'w'))
+    print(f'Mapped {len(import_to_wheel)} import name(s) to wheels')
+    return import_to_wheel
+
+
+if __name__ == '__main__':
+    main()

--- a/tasks/scripts/wheel-check/build_import_map.py
+++ b/tasks/scripts/wheel-check/build_import_map.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+"""Build a mapping from top-level import names to wheel filenames."""
 import json
 import os
 import sys
@@ -16,15 +17,16 @@ def main(wheels_dir=None, output_path='/tmp/import-to-wheel.json'):
     for f in sorted(os.listdir(wheels_dir)):
         if not f.endswith('.whl'):
             continue
-        whl_path = os.path.join(wheels_dir, f) if wheels_dir != '.' else f
+        whl_path = os.path.join(wheels_dir, f)
         try:
             inspection = inspect_wheel(whl_path)
             names = detect_import_names(inspection)
             for n in names:
                 import_to_wheel.setdefault(normalize(n), []).append(f)
-        except Exception:
-            pass
-    json.dump(import_to_wheel, open(output_path, 'w'))
+        except Exception as exc:
+            print(f'WARNING: skipping {f}: {exc}', file=sys.stderr)
+    with open(output_path, 'w') as f:
+        json.dump(import_to_wheel, f)
     print(f'Mapped {len(import_to_wheel)} import name(s) to wheels')
     return import_to_wheel
 

--- a/tasks/scripts/wheel-check/build_wheel_index.py
+++ b/tasks/scripts/wheel-check/build_wheel_index.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+"""Build a name-version to filename index from wheel files in a directory."""
 import json
 import os
 import sys
@@ -19,7 +20,8 @@ def main(wheels_dir=None, output_path='/tmp/wheel-index.json'):
         if len(parts) >= 2:
             key = normalize(parts[0]) + '-' + parts[1]
             wheel_index[key] = f
-    json.dump(wheel_index, open(output_path, 'w'))
+    with open(output_path, 'w') as f:
+        json.dump(wheel_index, f)
     print(f'Indexed {len(wheel_index)} wheel(s)')
     return wheel_index
 

--- a/tasks/scripts/wheel-check/build_wheel_index.py
+++ b/tasks/scripts/wheel-check/build_wheel_index.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from wheel_helpers import normalize
+
+
+def main(wheels_dir=None, output_path='/tmp/wheel-index.json'):
+    if wheels_dir is None:
+        wheels_dir = sys.argv[1] if len(sys.argv) > 1 else '.'
+    wheel_index = {}
+    for f in os.listdir(wheels_dir):
+        if not f.endswith('.whl'):
+            continue
+        parts = f.split('-')
+        if len(parts) >= 2:
+            key = normalize(parts[0]) + '-' + parts[1]
+            wheel_index[key] = f
+    json.dump(wheel_index, open(output_path, 'w'))
+    print(f'Indexed {len(wheel_index)} wheel(s)')
+    return wheel_index
+
+
+if __name__ == '__main__':
+    main()

--- a/tasks/scripts/wheel-check/detect_built_wheels.py
+++ b/tasks/scripts/wheel-check/detect_built_wheels.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+import json
+import os
+import re
+import sys
+
+
+def normalize(name):
+    return re.sub(r'[-_.]+', '_', name).lower()
+
+
+directory = sys.argv[1] if len(sys.argv) > 1 else '.'
+
+sdist_pkgs = set()
+for f in os.listdir(directory):
+    if not f.endswith('.tar.gz'):
+        continue
+    base = f[:-len('.tar.gz')]
+    name_part, _, version_part = base.rpartition('-')
+    if name_part:
+        sdist_pkgs.add(normalize(name_part))
+
+wheel_index = json.load(open('/tmp/wheel-index.json'))
+built = set()
+for key, whl in wheel_index.items():
+    pkg_name = normalize(key.rsplit('-', 1)[0])
+    if pkg_name in sdist_pkgs:
+        built.add(whl)
+
+if sdist_pkgs and built:
+    status = 'has_built'
+    print(f'Found {len(sdist_pkgs)} sdist(s), matched {len(built)} wheel(s) built from source')
+elif len(wheel_index) > 0 and not sdist_pkgs:
+    status = 'all_cached'
+    print(f'All {len(wheel_index)} wheel(s) pulled from cache — no sdists found')
+else:
+    status = 'no_sdists'
+    print('No sdists found — will test all wheels')
+
+json.dump({'status': status, 'wheels': sorted(built)}, open('/tmp/built-wheels.json', 'w'))

--- a/tasks/scripts/wheel-check/detect_built_wheels.py
+++ b/tasks/scripts/wheel-check/detect_built_wheels.py
@@ -1,40 +1,53 @@
 #!/usr/bin/env python3
+"""Detect which wheels were built from source by matching sdist archives to the wheel index."""
 import json
 import os
-import re
 import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from wheel_helpers import normalize
 
 
-def normalize(name):
-    return re.sub(r'[-_.]+', '_', name).lower()
+def main(directory=None, wheel_index_path='/tmp/wheel-index.json',
+         output_path='/tmp/built-wheels.json'):
+    if directory is None:
+        directory = sys.argv[1] if len(sys.argv) > 1 else '.'
+
+    sdist_pkgs = set()
+    for f in os.listdir(directory):
+        if not f.endswith('.tar.gz'):
+            continue
+        base = f[:-len('.tar.gz')]
+        name_part, _, version_part = base.rpartition('-')
+        if name_part:
+            sdist_pkgs.add(normalize(name_part))
+
+    with open(wheel_index_path) as fh:
+        wheel_index = json.load(fh)
+
+    built = set()
+    for key, whl in wheel_index.items():
+        pkg_name = normalize(key.rsplit('-', 1)[0])
+        if pkg_name in sdist_pkgs:
+            built.add(whl)
+
+    if sdist_pkgs and built:
+        status = 'has_built'
+        print(f'Found {len(sdist_pkgs)} sdist(s), matched {len(built)} wheel(s) built from source')
+    elif sdist_pkgs and not built:
+        status = 'no_match'
+        print(f'Found {len(sdist_pkgs)} sdist(s) but none matched the wheel index')
+    elif wheel_index and not sdist_pkgs:
+        status = 'all_cached'
+        print(f'All {len(wheel_index)} wheel(s) pulled from cache — no sdists found')
+    else:
+        status = 'no_sdists'
+        print('No sdists found — will test all wheels')
+
+    with open(output_path, 'w') as fh:
+        json.dump({'status': status, 'wheels': sorted(built)}, fh)
 
 
-directory = sys.argv[1] if len(sys.argv) > 1 else '.'
-
-sdist_pkgs = set()
-for f in os.listdir(directory):
-    if not f.endswith('.tar.gz'):
-        continue
-    base = f[:-len('.tar.gz')]
-    name_part, _, version_part = base.rpartition('-')
-    if name_part:
-        sdist_pkgs.add(normalize(name_part))
-
-wheel_index = json.load(open('/tmp/wheel-index.json'))
-built = set()
-for key, whl in wheel_index.items():
-    pkg_name = normalize(key.rsplit('-', 1)[0])
-    if pkg_name in sdist_pkgs:
-        built.add(whl)
-
-if sdist_pkgs and built:
-    status = 'has_built'
-    print(f'Found {len(sdist_pkgs)} sdist(s), matched {len(built)} wheel(s) built from source')
-elif len(wheel_index) > 0 and not sdist_pkgs:
-    status = 'all_cached'
-    print(f'All {len(wheel_index)} wheel(s) pulled from cache — no sdists found')
-else:
-    status = 'no_sdists'
-    print('No sdists found — will test all wheels')
-
-json.dump({'status': status, 'wheels': sorted(built)}, open('/tmp/built-wheels.json', 'w'))
+if __name__ == '__main__':
+    main()

--- a/tasks/scripts/wheel-check/test_build_import_map.py
+++ b/tasks/scripts/wheel-check/test_build_import_map.py
@@ -29,16 +29,14 @@ def _make_wheel(dir_path, name, version, files, top_level_txt=None):
 class TestBuildImportMap(unittest.TestCase):
     def _run_in_dir(self, wheels):
         """Create wheels in a temp dir and call main() directly."""
-        tmpdir = tempfile.mkdtemp()
-        output_path = os.path.join(tmpdir, 'import-to-wheel.json')
-        whl_names = []
-        for w in wheels:
-            whl_names.append(_make_wheel(tmpdir, **w))
-        imap = main(wheels_dir=tmpdir, output_path=output_path)
-        written = json.load(open(output_path))
-        for f in os.listdir(tmpdir):
-            os.unlink(os.path.join(tmpdir, f))
-        os.rmdir(tmpdir)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = os.path.join(tmpdir, 'import-to-wheel.json')
+            whl_names = []
+            for w in wheels:
+                whl_names.append(_make_wheel(tmpdir, **w))
+            imap = main(wheels_dir=tmpdir, output_path=output_path)
+            with open(output_path) as f:
+                written = json.load(f)
         return imap, written, whl_names
 
     def test_single_package(self):
@@ -106,16 +104,14 @@ class TestBuildImportMap(unittest.TestCase):
         self.assertEqual(imap['beta'], [names[0]])
 
     def test_writes_to_output_path(self):
-        tmpdir = tempfile.mkdtemp()
-        output_path = os.path.join(tmpdir, 'custom-map.json')
-        _make_wheel(tmpdir, 'pkg', '1.0', {'pkg/__init__.py': ''})
-        main(wheels_dir=tmpdir, output_path=output_path)
-        self.assertTrue(os.path.exists(output_path))
-        written = json.load(open(output_path))
-        self.assertIn('pkg', written)
-        for f in os.listdir(tmpdir):
-            os.unlink(os.path.join(tmpdir, f))
-        os.rmdir(tmpdir)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = os.path.join(tmpdir, 'custom-map.json')
+            _make_wheel(tmpdir, 'pkg', '1.0', {'pkg/__init__.py': ''})
+            main(wheels_dir=tmpdir, output_path=output_path)
+            self.assertTrue(os.path.exists(output_path))
+            with open(output_path) as f:
+                written = json.load(f)
+            self.assertIn('pkg', written)
 
 
 if __name__ == '__main__':

--- a/tasks/scripts/wheel-check/test_build_import_map.py
+++ b/tasks/scripts/wheel-check/test_build_import_map.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+import json
+import os
+import sys
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from build_import_map import main
+
+
+def _make_wheel(dir_path, name, version, files, top_level_txt=None):
+    """Create a minimal .whl in the given directory."""
+    dist_info = f"{name}-{version}.dist-info"
+    whl_name = f"{name}-{version}-py3-none-any.whl"
+    whl_path = os.path.join(dir_path, whl_name)
+    with zipfile.ZipFile(whl_path, 'w') as zf:
+        zf.writestr(f"{dist_info}/METADATA", f"Name: {name}\nVersion: {version}\n")
+        zf.writestr(f"{dist_info}/RECORD", "")
+        if top_level_txt is not None:
+            zf.writestr(f"{dist_info}/top_level.txt", top_level_txt)
+        for f_path, content in files.items():
+            zf.writestr(f_path, content)
+    return whl_name
+
+
+class TestBuildImportMap(unittest.TestCase):
+    def _run_in_dir(self, wheels):
+        """Create wheels in a temp dir and call main() directly."""
+        tmpdir = tempfile.mkdtemp()
+        output_path = os.path.join(tmpdir, 'import-to-wheel.json')
+        whl_names = []
+        for w in wheels:
+            whl_names.append(_make_wheel(tmpdir, **w))
+        imap = main(wheels_dir=tmpdir, output_path=output_path)
+        written = json.load(open(output_path))
+        for f in os.listdir(tmpdir):
+            os.unlink(os.path.join(tmpdir, f))
+        os.rmdir(tmpdir)
+        return imap, written, whl_names
+
+    def test_single_package(self):
+        imap, written, names = self._run_in_dir([{
+            'name': 'click', 'version': '8.1.0',
+            'files': {'click/__init__.py': '', 'click/core.py': ''},
+        }])
+        self.assertIn('click', imap)
+        self.assertEqual(imap['click'], [names[0]])
+        self.assertEqual(imap, written)
+
+    def test_multiple_packages(self):
+        imap, _, names = self._run_in_dir([
+            {
+                'name': 'click', 'version': '8.1.0',
+                'files': {'click/__init__.py': ''},
+            },
+            {
+                'name': 'flask', 'version': '3.0.0',
+                'files': {'flask/__init__.py': ''},
+            },
+        ])
+        self.assertIn('click', imap)
+        self.assertIn('flask', imap)
+
+    def test_different_import_name(self):
+        imap, _, names = self._run_in_dir([{
+            'name': 'beautifulsoup4', 'version': '4.12.0',
+            'files': {'bs4/__init__.py': '', 'bs4/element.py': ''},
+            'top_level_txt': 'bs4\n',
+        }])
+        self.assertIn('bs4', imap)
+        self.assertEqual(imap['bs4'], [names[0]])
+
+    def test_normalizes_import_name(self):
+        imap, _, names = self._run_in_dir([{
+            'name': 'My_Package', 'version': '1.0',
+            'files': {'My_Package/__init__.py': ''},
+            'top_level_txt': 'My_Package\n',
+        }])
+        self.assertIn('my_package', imap)
+
+    def test_empty_dir(self):
+        imap, _, _ = self._run_in_dir([])
+        self.assertEqual(len(imap), 0)
+
+    def test_data_only_wheel_skipped(self):
+        imap, _, _ = self._run_in_dir([{
+            'name': 'data_pkg', 'version': '1.0',
+            'files': {'data_pkg/data.csv': 'a,b'},
+        }])
+        self.assertEqual(len(imap), 0)
+
+    def test_multiple_imports_from_one_wheel(self):
+        imap, _, names = self._run_in_dir([{
+            'name': 'multi', 'version': '1.0',
+            'files': {
+                'alpha/__init__.py': '',
+                'beta/__init__.py': '',
+            },
+        }])
+        self.assertIn('alpha', imap)
+        self.assertIn('beta', imap)
+        self.assertEqual(imap['alpha'], [names[0]])
+        self.assertEqual(imap['beta'], [names[0]])
+
+    def test_writes_to_output_path(self):
+        tmpdir = tempfile.mkdtemp()
+        output_path = os.path.join(tmpdir, 'custom-map.json')
+        _make_wheel(tmpdir, 'pkg', '1.0', {'pkg/__init__.py': ''})
+        main(wheels_dir=tmpdir, output_path=output_path)
+        self.assertTrue(os.path.exists(output_path))
+        written = json.load(open(output_path))
+        self.assertIn('pkg', written)
+        for f in os.listdir(tmpdir):
+            os.unlink(os.path.join(tmpdir, f))
+        os.rmdir(tmpdir)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tasks/scripts/wheel-check/test_build_wheel_index.py
+++ b/tasks/scripts/wheel-check/test_build_wheel_index.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from build_wheel_index import main
+
+
+class TestBuildWheelIndex(unittest.TestCase):
+    def _run_in_dir(self, wheel_files):
+        """Create a temp dir with fake wheel files and call main() directly."""
+        tmpdir = tempfile.mkdtemp()
+        output_path = os.path.join(tmpdir, 'wheel-index.json')
+        for name in wheel_files:
+            open(os.path.join(tmpdir, name), 'w').close()
+        index = main(wheels_dir=tmpdir, output_path=output_path)
+        written = json.load(open(output_path))
+        for name in wheel_files:
+            os.unlink(os.path.join(tmpdir, name))
+        os.unlink(output_path)
+        os.rmdir(tmpdir)
+        return index, written
+
+    def test_single_wheel(self):
+        index, written = self._run_in_dir(['click-8.1.0-py3-none-any.whl'])
+        self.assertIn('click-8.1.0', index)
+        self.assertEqual(index['click-8.1.0'], 'click-8.1.0-py3-none-any.whl')
+        self.assertEqual(index, written)
+
+    def test_multiple_wheels(self):
+        index, _ = self._run_in_dir([
+            'click-8.1.0-py3-none-any.whl',
+            'flask-3.0.0-py3-none-any.whl',
+        ])
+        self.assertEqual(len(index), 2)
+        self.assertIn('click-8.1.0', index)
+        self.assertIn('flask-3.0.0', index)
+
+    def test_normalizes_name(self):
+        index, _ = self._run_in_dir([
+            'Pydantic_AI_Slim-2.10.0-py3-none-any.whl',
+        ])
+        self.assertIn('pydantic_ai_slim-2.10.0', index)
+
+    def test_ignores_non_wheel_files(self):
+        index, _ = self._run_in_dir([
+            'click-8.1.0-py3-none-any.whl',
+            'click-8.1.0.tar.gz',
+            'README.md',
+        ])
+        self.assertEqual(len(index), 1)
+
+    def test_empty_dir(self):
+        index, _ = self._run_in_dir([])
+        self.assertEqual(len(index), 0)
+
+    def test_build_number_wheel(self):
+        index, _ = self._run_in_dir([
+            'presidio_analyzer-2.2.359-0-py3-none-any.whl',
+        ])
+        self.assertIn('presidio_analyzer-2.2.359', index)
+        self.assertEqual(
+            index['presidio_analyzer-2.2.359'],
+            'presidio_analyzer-2.2.359-0-py3-none-any.whl',
+        )
+
+    def test_writes_to_output_path(self):
+        tmpdir = tempfile.mkdtemp()
+        output_path = os.path.join(tmpdir, 'custom-index.json')
+        open(os.path.join(tmpdir, 'a-1.0-py3-none-any.whl'), 'w').close()
+        main(wheels_dir=tmpdir, output_path=output_path)
+        self.assertTrue(os.path.exists(output_path))
+        written = json.load(open(output_path))
+        self.assertIn('a-1.0', written)
+        os.unlink(os.path.join(tmpdir, 'a-1.0-py3-none-any.whl'))
+        os.unlink(output_path)
+        os.rmdir(tmpdir)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tasks/scripts/wheel-check/test_build_wheel_index.py
+++ b/tasks/scripts/wheel-check/test_build_wheel_index.py
@@ -13,16 +13,13 @@ from build_wheel_index import main
 class TestBuildWheelIndex(unittest.TestCase):
     def _run_in_dir(self, wheel_files):
         """Create a temp dir with fake wheel files and call main() directly."""
-        tmpdir = tempfile.mkdtemp()
-        output_path = os.path.join(tmpdir, 'wheel-index.json')
-        for name in wheel_files:
-            open(os.path.join(tmpdir, name), 'w').close()
-        index = main(wheels_dir=tmpdir, output_path=output_path)
-        written = json.load(open(output_path))
-        for name in wheel_files:
-            os.unlink(os.path.join(tmpdir, name))
-        os.unlink(output_path)
-        os.rmdir(tmpdir)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = os.path.join(tmpdir, 'wheel-index.json')
+            for name in wheel_files:
+                Path(os.path.join(tmpdir, name)).touch()
+            index = main(wheels_dir=tmpdir, output_path=output_path)
+            with open(output_path) as f:
+                written = json.load(f)
         return index, written
 
     def test_single_wheel(self):
@@ -69,16 +66,14 @@ class TestBuildWheelIndex(unittest.TestCase):
         )
 
     def test_writes_to_output_path(self):
-        tmpdir = tempfile.mkdtemp()
-        output_path = os.path.join(tmpdir, 'custom-index.json')
-        open(os.path.join(tmpdir, 'a-1.0-py3-none-any.whl'), 'w').close()
-        main(wheels_dir=tmpdir, output_path=output_path)
-        self.assertTrue(os.path.exists(output_path))
-        written = json.load(open(output_path))
-        self.assertIn('a-1.0', written)
-        os.unlink(os.path.join(tmpdir, 'a-1.0-py3-none-any.whl'))
-        os.unlink(output_path)
-        os.rmdir(tmpdir)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = os.path.join(tmpdir, 'custom-index.json')
+            Path(os.path.join(tmpdir, 'a-1.0-py3-none-any.whl')).touch()
+            main(wheels_dir=tmpdir, output_path=output_path)
+            self.assertTrue(os.path.exists(output_path))
+            with open(output_path) as f:
+                written = json.load(f)
+            self.assertIn('a-1.0', written)
 
 
 if __name__ == '__main__':

--- a/tasks/scripts/wheel-check/test_detect_built_wheels.py
+++ b/tasks/scripts/wheel-check/test_detect_built_wheels.py
@@ -1,42 +1,36 @@
 #!/usr/bin/env python3
 import json
 import os
-import subprocess
+import shutil
 import sys
 import tempfile
 import unittest
 from pathlib import Path
 
-
-SCRIPT = str(Path(__file__).resolve().parent / 'detect_built_wheels.py')
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from detect_built_wheels import main
 
 
 class TestDetectBuiltWheels(unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
-        self.wheel_index_path = '/tmp/wheel-index.json'
-
-    def tearDown(self):
-        import shutil
-        shutil.rmtree(self.tmpdir)
-        for f in [self.wheel_index_path, '/tmp/built-wheels.json']:
-            if os.path.exists(f):
-                os.unlink(f)
+        self.addCleanup(shutil.rmtree, self.tmpdir)
+        self.wheel_index_path = os.path.join(self.tmpdir, 'wheel-index.json')
+        self.built_wheels_path = os.path.join(self.tmpdir, 'built-wheels.json')
 
     def _write_wheel_index(self, index):
         with open(self.wheel_index_path, 'w') as f:
             json.dump(index, f)
 
     def _create_file(self, name):
-        open(os.path.join(self.tmpdir, name), 'w').close()
+        Path(os.path.join(self.tmpdir, name)).touch()
 
     def _run(self):
-        result = subprocess.run(
-            [sys.executable, SCRIPT, self.tmpdir],
-            capture_output=True, text=True,
-        )
-        with open('/tmp/built-wheels.json') as f:
-            return json.load(f), result.stdout
+        main(directory=self.tmpdir,
+             wheel_index_path=self.wheel_index_path,
+             output_path=self.built_wheels_path)
+        with open(self.built_wheels_path) as f:
+            return json.load(f)
 
     def test_has_built(self):
         self._write_wheel_index({
@@ -47,11 +41,10 @@ class TestDetectBuiltWheels(unittest.TestCase):
         self._create_file('click-8.1.0-py3-none-any.whl')
         self._create_file('requests-2.31.0-py3-none-any.whl')
 
-        data, stdout = self._run()
+        data = self._run()
         self.assertEqual(data['status'], 'has_built')
         self.assertIn('click-8.1.0-py3-none-any.whl', data['wheels'])
         self.assertNotIn('requests-2.31.0-py3-none-any.whl', data['wheels'])
-        self.assertIn('1 sdist', stdout)
 
     def test_all_cached(self):
         self._write_wheel_index({
@@ -59,15 +52,14 @@ class TestDetectBuiltWheels(unittest.TestCase):
         })
         self._create_file('click-8.1.0-py3-none-any.whl')
 
-        data, stdout = self._run()
+        data = self._run()
         self.assertEqual(data['status'], 'all_cached')
         self.assertEqual(data['wheels'], [])
-        self.assertIn('cache', stdout)
 
     def test_no_sdists_empty_dir(self):
         self._write_wheel_index({})
 
-        data, stdout = self._run()
+        data = self._run()
         self.assertEqual(data['status'], 'no_sdists')
 
     def test_multi_segment_name(self):
@@ -77,7 +69,7 @@ class TestDetectBuiltWheels(unittest.TestCase):
         self._create_file('azure-mgmt-resource-1.0.0.tar.gz')
         self._create_file('azure_mgmt_resource-1.0.0-py3-none-any.whl')
 
-        data, _ = self._run()
+        data = self._run()
         self.assertEqual(data['status'], 'has_built')
         self.assertIn('azure_mgmt_resource-1.0.0-py3-none-any.whl', data['wheels'])
 
@@ -90,10 +82,19 @@ class TestDetectBuiltWheels(unittest.TestCase):
         self._create_file('click-8.1.0.tar.gz')
         self._create_file('flask-2.3.0.tar.gz')
 
-        data, stdout = self._run()
+        data = self._run()
         self.assertEqual(data['status'], 'has_built')
         self.assertEqual(len(data['wheels']), 2)
-        self.assertIn('2 sdist', stdout)
+
+    def test_no_match(self):
+        self._write_wheel_index({
+            'other-1.0.0': 'other-1.0.0-py3-none-any.whl',
+        })
+        self._create_file('unrelated-2.0.0.tar.gz')
+
+        data = self._run()
+        self.assertEqual(data['status'], 'no_match')
+        self.assertEqual(data['wheels'], [])
 
 
 if __name__ == '__main__':

--- a/tasks/scripts/wheel-check/test_detect_built_wheels.py
+++ b/tasks/scripts/wheel-check/test_detect_built_wheels.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = str(Path(__file__).resolve().parent / 'detect_built_wheels.py')
+
+
+class TestDetectBuiltWheels(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.wheel_index_path = '/tmp/wheel-index.json'
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmpdir)
+        for f in [self.wheel_index_path, '/tmp/built-wheels.json']:
+            if os.path.exists(f):
+                os.unlink(f)
+
+    def _write_wheel_index(self, index):
+        with open(self.wheel_index_path, 'w') as f:
+            json.dump(index, f)
+
+    def _create_file(self, name):
+        open(os.path.join(self.tmpdir, name), 'w').close()
+
+    def _run(self):
+        result = subprocess.run(
+            [sys.executable, SCRIPT, self.tmpdir],
+            capture_output=True, text=True,
+        )
+        with open('/tmp/built-wheels.json') as f:
+            return json.load(f), result.stdout
+
+    def test_has_built(self):
+        self._write_wheel_index({
+            'click-8.1.0': 'click-8.1.0-py3-none-any.whl',
+            'requests-2.31.0': 'requests-2.31.0-py3-none-any.whl',
+        })
+        self._create_file('click-8.1.0.tar.gz')
+        self._create_file('click-8.1.0-py3-none-any.whl')
+        self._create_file('requests-2.31.0-py3-none-any.whl')
+
+        data, stdout = self._run()
+        self.assertEqual(data['status'], 'has_built')
+        self.assertIn('click-8.1.0-py3-none-any.whl', data['wheels'])
+        self.assertNotIn('requests-2.31.0-py3-none-any.whl', data['wheels'])
+        self.assertIn('1 sdist', stdout)
+
+    def test_all_cached(self):
+        self._write_wheel_index({
+            'click-8.1.0': 'click-8.1.0-py3-none-any.whl',
+        })
+        self._create_file('click-8.1.0-py3-none-any.whl')
+
+        data, stdout = self._run()
+        self.assertEqual(data['status'], 'all_cached')
+        self.assertEqual(data['wheels'], [])
+        self.assertIn('cache', stdout)
+
+    def test_no_sdists_empty_dir(self):
+        self._write_wheel_index({})
+
+        data, stdout = self._run()
+        self.assertEqual(data['status'], 'no_sdists')
+
+    def test_multi_segment_name(self):
+        self._write_wheel_index({
+            'azure_mgmt_resource-1.0.0': 'azure_mgmt_resource-1.0.0-py3-none-any.whl',
+        })
+        self._create_file('azure-mgmt-resource-1.0.0.tar.gz')
+        self._create_file('azure_mgmt_resource-1.0.0-py3-none-any.whl')
+
+        data, _ = self._run()
+        self.assertEqual(data['status'], 'has_built')
+        self.assertIn('azure_mgmt_resource-1.0.0-py3-none-any.whl', data['wheels'])
+
+    def test_multiple_sdists(self):
+        self._write_wheel_index({
+            'click-8.1.0': 'click-8.1.0-py3-none-any.whl',
+            'flask-2.3.0': 'flask-2.3.0-py3-none-any.whl',
+            'requests-2.31.0': 'requests-2.31.0-py3-none-any.whl',
+        })
+        self._create_file('click-8.1.0.tar.gz')
+        self._create_file('flask-2.3.0.tar.gz')
+
+        data, stdout = self._run()
+        self.assertEqual(data['status'], 'has_built')
+        self.assertEqual(len(data['wheels']), 2)
+        self.assertIn('2 sdist', stdout)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tasks/scripts/wheel-check/test_verify_import.py
+++ b/tasks/scripts/wheel-check/test_verify_import.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from verify_import import (
+    check_import,
+    classify_wheel,
+    detect_import_names,
+    inspect_wheel,
+    main,
+    parse_dist_info,
+)
+
+
+def _make_wheel(name, version, files, top_level_txt=None, dir_entries=None):
+    """Create a minimal .whl file (zip) with the given structure."""
+    dist_info = f"{name}-{version}.dist-info"
+    fd, path = tempfile.mkstemp(suffix='.whl')
+    os.close(fd)
+    with zipfile.ZipFile(path, 'w') as zf:
+        zf.writestr(f"{dist_info}/METADATA", f"Name: {name}\nVersion: {version}\n")
+        zf.writestr(f"{dist_info}/RECORD", "")
+        if top_level_txt is not None:
+            zf.writestr(f"{dist_info}/top_level.txt", top_level_txt)
+        for f_path, content in files.items():
+            zf.writestr(f_path, content)
+        for d in (dir_entries or []):
+            zf.mkdir(d)
+    return path
+
+
+class TestInspectWheel(unittest.TestCase):
+    def test_basic_package(self):
+        path = _make_wheel('foo', '1.0', {'foo/__init__.py': '', 'foo/core.py': 'x=1'})
+        result = inspect_wheel(path)
+        self.assertEqual(result['dist_info_dir'], 'foo-1.0.dist-info')
+        self.assertTrue(result['has_source'])
+        self.assertIn('foo/__init__.py', result['content_entries'])
+        self.assertIn('foo/core.py', result['content_entries'])
+        os.unlink(path)
+
+    def test_top_level_txt(self):
+        path = _make_wheel('bar', '2.0', {'bar/__init__.py': ''}, top_level_txt='bar\n')
+        result = inspect_wheel(path)
+        self.assertEqual(result['top_level_txt'], 'bar\n')
+        os.unlink(path)
+
+    def test_no_top_level_txt(self):
+        path = _make_wheel('baz', '1.0', {'baz/__init__.py': ''})
+        result = inspect_wheel(path)
+        self.assertIsNone(result['top_level_txt'])
+        os.unlink(path)
+
+    def test_data_only(self):
+        path = _make_wheel('data_pkg', '1.0', {'data_pkg/data.txt': 'hello'})
+        result = inspect_wheel(path)
+        self.assertFalse(result['has_source'])
+        os.unlink(path)
+
+    def test_empty_wheel(self):
+        path = _make_wheel('empty', '1.0', {})
+        result = inspect_wheel(path)
+        self.assertEqual(result['content_entries'], [])
+        self.assertFalse(result['has_source'])
+        os.unlink(path)
+
+    def test_filters_dist_info_and_data(self):
+        path = _make_wheel('pkg', '1.0', {
+            'pkg/__init__.py': '',
+            'pkg-1.0.data/scripts/run.sh': '#!/bin/bash',
+        })
+        result = inspect_wheel(path)
+        content_names = result['content_entries']
+        self.assertIn('pkg/__init__.py', content_names)
+        self.assertNotIn('pkg-1.0.data/scripts/run.sh', content_names)
+        os.unlink(path)
+
+    def test_extension_module(self):
+        path = _make_wheel('ext', '1.0', {
+            'ext/__init__.py': '',
+            'ext/_fast.cpython-312-x86_64-linux-gnu.so': b'\x00',
+        })
+        result = inspect_wheel(path)
+        self.assertTrue(result['has_source'])
+        os.unlink(path)
+
+    def test_directory_entries_filtered(self):
+        path = _make_wheel('pkg', '1.0', {'pkg/__init__.py': ''},
+                           dir_entries=['pkg/'])
+        result = inspect_wheel(path)
+        self.assertNotIn('pkg/', result['content_entries'])
+        self.assertIn('pkg/__init__.py', result['content_entries'])
+        os.unlink(path)
+
+
+class TestParseDistInfo(unittest.TestCase):
+    def test_normal(self):
+        name, version = parse_dist_info('click-8.1.0.dist-info')
+        self.assertEqual(name, 'click')
+        self.assertEqual(version, '8.1.0')
+
+    def test_underscore_name(self):
+        name, version = parse_dist_info('pydantic_ai_slim-2.10.0.dist-info')
+        self.assertEqual(name, 'pydantic-ai-slim')
+        self.assertEqual(version, '2.10.0')
+
+    def test_no_version(self):
+        name, version = parse_dist_info('weird.dist-info')
+        self.assertEqual(name, 'weird')
+        self.assertEqual(version, 'unknown')
+
+
+class TestClassifyWheel(unittest.TestCase):
+    def test_empty(self):
+        self.assertEqual(classify_wheel({'content_entries': [], 'has_source': False}), 'empty')
+
+    def test_data_only(self):
+        self.assertEqual(classify_wheel({
+            'content_entries': ['pkg/data.txt'],
+            'has_source': False,
+        }), 'data-only')
+
+    def test_importable(self):
+        self.assertEqual(classify_wheel({
+            'content_entries': ['pkg/__init__.py'],
+            'has_source': True,
+        }), 'importable')
+
+
+class TestDetectImportNames(unittest.TestCase):
+    def test_regular_package(self):
+        path = _make_wheel('mypkg', '1.0', {
+            'mypkg/__init__.py': '',
+            'mypkg/core.py': '',
+        })
+        inspection = inspect_wheel(path)
+        names = detect_import_names(inspection)
+        self.assertEqual(names, {'mypkg'})
+        os.unlink(path)
+
+    def test_top_level_module(self):
+        path = _make_wheel('single', '1.0', {'mymod.py': 'x=1'})
+        inspection = inspect_wheel(path)
+        names = detect_import_names(inspection)
+        self.assertIn('mymod', names)
+        os.unlink(path)
+
+    def test_extension_module(self):
+        path = _make_wheel('ext', '1.0', {
+            'fastmod.cpython-312-x86_64-linux-gnu.so': b'\x00',
+        })
+        inspection = inspect_wheel(path)
+        names = detect_import_names(inspection)
+        self.assertIn('fastmod', names)
+        os.unlink(path)
+
+    def test_pyd_extension(self):
+        path = _make_wheel('ext', '1.0', {'winmod.pyd': b'\x00'})
+        inspection = inspect_wheel(path)
+        names = detect_import_names(inspection)
+        self.assertIn('winmod', names)
+        os.unlink(path)
+
+    def test_filters_underscore_prefixed(self):
+        path = _make_wheel('pkg', '1.0', {
+            'pkg/__init__.py': '',
+            '_internal/__init__.py': '',
+        })
+        inspection = inspect_wheel(path)
+        names = detect_import_names(inspection)
+        self.assertIn('pkg', names)
+        self.assertNotIn('_internal', names)
+        os.unlink(path)
+
+    def test_filters_tests(self):
+        path = _make_wheel('pkg', '1.0', {
+            'pkg/__init__.py': '',
+            'tests/__init__.py': '',
+        })
+        inspection = inspect_wheel(path)
+        names = detect_import_names(inspection)
+        self.assertIn('pkg', names)
+        self.assertNotIn('tests', names)
+        os.unlink(path)
+
+    def test_filters_libs(self):
+        path = _make_wheel('pkg', '1.0', {
+            'pkg/__init__.py': '',
+            'pkg.libs/libfoo.so': b'\x00',
+        })
+        inspection = inspect_wheel(path)
+        names = detect_import_names(inspection)
+        self.assertIn('pkg', names)
+        self.assertNotIn('pkg.libs', names)
+        os.unlink(path)
+
+    def test_filters_pytest_prefix(self):
+        """pytest_ imports are filtered when a non-pytest import exists."""
+        path = _make_wheel('pytest_cov', '1.0', {
+            'pytest_cov/__init__.py': '',
+            'pytest_cov/plugin.py': '',
+            'covmod/__init__.py': '',
+        })
+        inspection = inspect_wheel(path)
+        names = detect_import_names(inspection)
+        self.assertIn('covmod', names)
+        self.assertNotIn('pytest_cov', names)
+        os.unlink(path)
+
+    def test_pytest_prefix_only_package(self):
+        """When only pytest_ imports exist, they're kept after fallback filtering."""
+        path = _make_wheel('pytest_mock', '1.0', {
+            'pytest_mock/__init__.py': '',
+        })
+        inspection = inspect_wheel(path)
+        names = detect_import_names(inspection)
+        self.assertEqual(names, {'pytest_mock'})
+        os.unlink(path)
+
+    def test_top_level_txt_adds_valid_name(self):
+        path = _make_wheel('pkg', '1.0', {
+            'mypkg/__init__.py': '',
+            'extra/__init__.py': '',
+        }, top_level_txt='mypkg\nextra\n')
+        inspection = inspect_wheel(path)
+        names = detect_import_names(inspection)
+        self.assertIn('mypkg', names)
+        self.assertIn('extra', names)
+        os.unlink(path)
+
+    def test_top_level_txt_ignores_unknown(self):
+        path = _make_wheel('pkg', '1.0', {
+            'real/__init__.py': '',
+        }, top_level_txt='real\nphantom\n')
+        inspection = inspect_wheel(path)
+        names = detect_import_names(inspection)
+        self.assertIn('real', names)
+        self.assertNotIn('phantom', names)
+        os.unlink(path)
+
+    def test_top_level_txt_ignores_path_separators(self):
+        path = _make_wheel('pkg', '1.0', {
+            'real/__init__.py': '',
+        }, top_level_txt='real\nbad/path\nback\\slash\n')
+        inspection = inspect_wheel(path)
+        names = detect_import_names(inspection)
+        self.assertIn('real', names)
+        self.assertNotIn('bad/path', names)
+        self.assertNotIn('back\\slash', names)
+        os.unlink(path)
+
+    def test_top_level_txt_ignores_tests(self):
+        path = _make_wheel('pkg', '1.0', {
+            'real/__init__.py': '',
+            'tests/__init__.py': '',
+        }, top_level_txt='real\ntests\n')
+        inspection = inspect_wheel(path)
+        names = detect_import_names(inspection)
+        self.assertIn('real', names)
+        self.assertNotIn('tests', names)
+        os.unlink(path)
+
+    def test_top_level_txt_skips_underscore_when_imports_exist(self):
+        path = _make_wheel('pkg', '1.0', {
+            'real/__init__.py': '',
+            '_private/__init__.py': '',
+        }, top_level_txt='real\n_private\n')
+        inspection = inspect_wheel(path)
+        names = detect_import_names(inspection)
+        self.assertIn('real', names)
+        self.assertNotIn('_private', names)
+        os.unlink(path)
+
+    def test_namespace_package(self):
+        path = _make_wheel('ns_pkg', '1.0', {
+            'ns/sub/__init__.py': '',
+            'ns/sub/mod.py': '',
+        })
+        inspection = inspect_wheel(path)
+        names = detect_import_names(inspection)
+        self.assertIn('ns.sub', names)
+        os.unlink(path)
+
+    def test_multiple_packages(self):
+        path = _make_wheel('multi', '1.0', {
+            'alpha/__init__.py': '',
+            'beta/__init__.py': '',
+        })
+        inspection = inspect_wheel(path)
+        names = detect_import_names(inspection)
+        self.assertIn('alpha', names)
+        self.assertIn('beta', names)
+        os.unlink(path)
+
+
+class TestCheckImport(unittest.TestCase):
+    def test_stdlib_module(self):
+        success, msg = check_import('json')
+        self.assertTrue(success)
+        self.assertIn('json', msg)
+
+    def test_nonexistent_module(self):
+        success, msg = check_import('nonexistent_module_xyz_12345')
+        self.assertFalse(success)
+        self.assertIn('ImportError', msg)
+
+    def test_non_import_error(self):
+        with patch('verify_import.importlib.import_module', side_effect=RuntimeError('boom')):
+            success, msg = check_import('anything')
+            self.assertFalse(success)
+            self.assertIn('RuntimeError', msg)
+            self.assertIn('boom', msg)
+
+
+class TestMain(unittest.TestCase):
+    def _run_main(self, *args):
+        """Run main() in-process, capturing stdout and SystemExit."""
+        with patch('sys.argv', ['verify_import.py'] + list(args)):
+            with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
+                try:
+                    main()
+                    return 0, mock_out.getvalue()
+                except SystemExit as e:
+                    return e.code, mock_out.getvalue()
+
+    def test_classify_only_importable(self):
+        path = _make_wheel('clstest', '1.0', {'clstest/__init__.py': ''})
+        rc, _ = self._run_main('--classify-only', path)
+        self.assertEqual(rc, 10)
+        os.unlink(path)
+
+    def test_classify_only_empty(self):
+        path = _make_wheel('emptytest', '1.0', {})
+        rc, out = self._run_main('--classify-only', path)
+        self.assertEqual(rc, 0)
+        d = json.loads(out)
+        self.assertEqual(d['status'], 'SKIP')
+        self.assertIn('empty', d['reason'])
+        os.unlink(path)
+
+    def test_classify_only_data_only(self):
+        path = _make_wheel('datatest', '1.0', {'datatest/data.csv': 'a,b,c'})
+        rc, out = self._run_main('--classify-only', path)
+        self.assertEqual(rc, 0)
+        d = json.loads(out)
+        self.assertEqual(d['status'], 'SKIP')
+        self.assertIn('data-only', d['reason'])
+        os.unlink(path)
+
+    def test_missing_file(self):
+        rc, out = self._run_main('/tmp/nonexistent-wheel-12345.whl')
+        self.assertEqual(rc, 2)
+        d = json.loads(out)
+        self.assertEqual(d['status'], 'ERROR')
+
+    def test_no_args(self):
+        rc, out = self._run_main()
+        self.assertEqual(rc, 2)
+
+    def test_import_pass(self):
+        path = _make_wheel('jsonwrap', '1.0', {'json_wrap/__init__.py': ''})
+        rc, out = self._run_main(path)
+        d = json.loads(out)
+        self.assertIn(d['status'], ('PASS', 'FAIL'))
+        self.assertEqual(d['wheel'], os.path.basename(path))
+        self.assertIn('dist_name', d)
+        self.assertIn('version', d)
+        os.unlink(path)
+
+    def test_import_fail(self):
+        path = _make_wheel('xyznonexist', '1.0', {
+            'xyznonexist_pkg/__init__.py': 'import nonexistent_module_abc_999',
+        })
+        rc, out = self._run_main(path)
+        d = json.loads(out)
+        self.assertEqual(d['status'], 'FAIL')
+        self.assertEqual(rc, 1)
+        self.assertTrue(any(not t['success'] for t in d['imports_tested']))
+        os.unlink(path)
+
+    def test_no_import_names_detected(self):
+        path = _make_wheel('odd', '1.0', {'_only_private/__init__.py': ''})
+        rc, out = self._run_main(path)
+        d = json.loads(out)
+        self.assertIn(d['status'], ('PASS', 'FAIL'))
+        os.unlink(path)
+
+    def test_no_dist_info(self):
+        fd, path = tempfile.mkstemp(suffix='.whl')
+        os.close(fd)
+        with zipfile.ZipFile(path, 'w') as zf:
+            zf.writestr('pkg/__init__.py', '')
+        rc, out = self._run_main(path)
+        d = json.loads(out)
+        self.assertEqual(d['dist_name'], 'unknown')
+        os.unlink(path)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tasks/scripts/wheel-check/test_verify_import.py
+++ b/tasks/scripts/wheel-check/test_verify_import.py
@@ -38,42 +38,42 @@ def _make_wheel(name, version, files, top_level_txt=None, dir_entries=None):
 
 
 class TestInspectWheel(unittest.TestCase):
+    def _wheel(self, *args, **kwargs):
+        path = _make_wheel(*args, **kwargs)
+        self.addCleanup(lambda: os.path.exists(path) and os.unlink(path))
+        return path
+
     def test_basic_package(self):
-        path = _make_wheel('foo', '1.0', {'foo/__init__.py': '', 'foo/core.py': 'x=1'})
+        path = self._wheel('foo', '1.0', {'foo/__init__.py': '', 'foo/core.py': 'x=1'})
         result = inspect_wheel(path)
         self.assertEqual(result['dist_info_dir'], 'foo-1.0.dist-info')
         self.assertTrue(result['has_source'])
         self.assertIn('foo/__init__.py', result['content_entries'])
         self.assertIn('foo/core.py', result['content_entries'])
-        os.unlink(path)
 
     def test_top_level_txt(self):
-        path = _make_wheel('bar', '2.0', {'bar/__init__.py': ''}, top_level_txt='bar\n')
+        path = self._wheel('bar', '2.0', {'bar/__init__.py': ''}, top_level_txt='bar\n')
         result = inspect_wheel(path)
         self.assertEqual(result['top_level_txt'], 'bar\n')
-        os.unlink(path)
 
     def test_no_top_level_txt(self):
-        path = _make_wheel('baz', '1.0', {'baz/__init__.py': ''})
+        path = self._wheel('baz', '1.0', {'baz/__init__.py': ''})
         result = inspect_wheel(path)
         self.assertIsNone(result['top_level_txt'])
-        os.unlink(path)
 
     def test_data_only(self):
-        path = _make_wheel('data_pkg', '1.0', {'data_pkg/data.txt': 'hello'})
+        path = self._wheel('data_pkg', '1.0', {'data_pkg/data.txt': 'hello'})
         result = inspect_wheel(path)
         self.assertFalse(result['has_source'])
-        os.unlink(path)
 
     def test_empty_wheel(self):
-        path = _make_wheel('empty', '1.0', {})
+        path = self._wheel('empty', '1.0', {})
         result = inspect_wheel(path)
         self.assertEqual(result['content_entries'], [])
         self.assertFalse(result['has_source'])
-        os.unlink(path)
 
     def test_filters_dist_info_and_data(self):
-        path = _make_wheel('pkg', '1.0', {
+        path = self._wheel('pkg', '1.0', {
             'pkg/__init__.py': '',
             'pkg-1.0.data/scripts/run.sh': '#!/bin/bash',
         })
@@ -81,24 +81,21 @@ class TestInspectWheel(unittest.TestCase):
         content_names = result['content_entries']
         self.assertIn('pkg/__init__.py', content_names)
         self.assertNotIn('pkg-1.0.data/scripts/run.sh', content_names)
-        os.unlink(path)
 
     def test_extension_module(self):
-        path = _make_wheel('ext', '1.0', {
+        path = self._wheel('ext', '1.0', {
             'ext/__init__.py': '',
             'ext/_fast.cpython-312-x86_64-linux-gnu.so': b'\x00',
         })
         result = inspect_wheel(path)
         self.assertTrue(result['has_source'])
-        os.unlink(path)
 
     def test_directory_entries_filtered(self):
-        path = _make_wheel('pkg', '1.0', {'pkg/__init__.py': ''},
+        path = self._wheel('pkg', '1.0', {'pkg/__init__.py': ''},
                            dir_entries=['pkg/'])
         result = inspect_wheel(path)
         self.assertNotIn('pkg/', result['content_entries'])
         self.assertIn('pkg/__init__.py', result['content_entries'])
-        os.unlink(path)
 
 
 class TestParseDistInfo(unittest.TestCase):
@@ -136,41 +133,42 @@ class TestClassifyWheel(unittest.TestCase):
 
 
 class TestDetectImportNames(unittest.TestCase):
+    def _wheel(self, *args, **kwargs):
+        path = _make_wheel(*args, **kwargs)
+        self.addCleanup(lambda: os.path.exists(path) and os.unlink(path))
+        return path
+
     def test_regular_package(self):
-        path = _make_wheel('mypkg', '1.0', {
+        path = self._wheel('mypkg', '1.0', {
             'mypkg/__init__.py': '',
             'mypkg/core.py': '',
         })
         inspection = inspect_wheel(path)
         names = detect_import_names(inspection)
         self.assertEqual(names, {'mypkg'})
-        os.unlink(path)
 
     def test_top_level_module(self):
-        path = _make_wheel('single', '1.0', {'mymod.py': 'x=1'})
+        path = self._wheel('single', '1.0', {'mymod.py': 'x=1'})
         inspection = inspect_wheel(path)
         names = detect_import_names(inspection)
         self.assertIn('mymod', names)
-        os.unlink(path)
 
     def test_extension_module(self):
-        path = _make_wheel('ext', '1.0', {
+        path = self._wheel('ext', '1.0', {
             'fastmod.cpython-312-x86_64-linux-gnu.so': b'\x00',
         })
         inspection = inspect_wheel(path)
         names = detect_import_names(inspection)
         self.assertIn('fastmod', names)
-        os.unlink(path)
 
     def test_pyd_extension(self):
-        path = _make_wheel('ext', '1.0', {'winmod.pyd': b'\x00'})
+        path = self._wheel('ext', '1.0', {'winmod.pyd': b'\x00'})
         inspection = inspect_wheel(path)
         names = detect_import_names(inspection)
         self.assertIn('winmod', names)
-        os.unlink(path)
 
     def test_filters_underscore_prefixed(self):
-        path = _make_wheel('pkg', '1.0', {
+        path = self._wheel('pkg', '1.0', {
             'pkg/__init__.py': '',
             '_internal/__init__.py': '',
         })
@@ -178,10 +176,9 @@ class TestDetectImportNames(unittest.TestCase):
         names = detect_import_names(inspection)
         self.assertIn('pkg', names)
         self.assertNotIn('_internal', names)
-        os.unlink(path)
 
     def test_filters_tests(self):
-        path = _make_wheel('pkg', '1.0', {
+        path = self._wheel('pkg', '1.0', {
             'pkg/__init__.py': '',
             'tests/__init__.py': '',
         })
@@ -189,10 +186,9 @@ class TestDetectImportNames(unittest.TestCase):
         names = detect_import_names(inspection)
         self.assertIn('pkg', names)
         self.assertNotIn('tests', names)
-        os.unlink(path)
 
     def test_filters_libs(self):
-        path = _make_wheel('pkg', '1.0', {
+        path = self._wheel('pkg', '1.0', {
             'pkg/__init__.py': '',
             'pkg.libs/libfoo.so': b'\x00',
         })
@@ -200,11 +196,10 @@ class TestDetectImportNames(unittest.TestCase):
         names = detect_import_names(inspection)
         self.assertIn('pkg', names)
         self.assertNotIn('pkg.libs', names)
-        os.unlink(path)
 
     def test_filters_pytest_prefix(self):
         """pytest_ imports are filtered when a non-pytest import exists."""
-        path = _make_wheel('pytest_cov', '1.0', {
+        path = self._wheel('pytest_cov', '1.0', {
             'pytest_cov/__init__.py': '',
             'pytest_cov/plugin.py': '',
             'covmod/__init__.py': '',
@@ -213,20 +208,18 @@ class TestDetectImportNames(unittest.TestCase):
         names = detect_import_names(inspection)
         self.assertIn('covmod', names)
         self.assertNotIn('pytest_cov', names)
-        os.unlink(path)
 
     def test_pytest_prefix_only_package(self):
         """When only pytest_ imports exist, they're kept after fallback filtering."""
-        path = _make_wheel('pytest_mock', '1.0', {
+        path = self._wheel('pytest_mock', '1.0', {
             'pytest_mock/__init__.py': '',
         })
         inspection = inspect_wheel(path)
         names = detect_import_names(inspection)
         self.assertEqual(names, {'pytest_mock'})
-        os.unlink(path)
 
     def test_top_level_txt_adds_valid_name(self):
-        path = _make_wheel('pkg', '1.0', {
+        path = self._wheel('pkg', '1.0', {
             'mypkg/__init__.py': '',
             'extra/__init__.py': '',
         }, top_level_txt='mypkg\nextra\n')
@@ -234,20 +227,18 @@ class TestDetectImportNames(unittest.TestCase):
         names = detect_import_names(inspection)
         self.assertIn('mypkg', names)
         self.assertIn('extra', names)
-        os.unlink(path)
 
     def test_top_level_txt_ignores_unknown(self):
-        path = _make_wheel('pkg', '1.0', {
+        path = self._wheel('pkg', '1.0', {
             'real/__init__.py': '',
         }, top_level_txt='real\nphantom\n')
         inspection = inspect_wheel(path)
         names = detect_import_names(inspection)
         self.assertIn('real', names)
         self.assertNotIn('phantom', names)
-        os.unlink(path)
 
     def test_top_level_txt_ignores_path_separators(self):
-        path = _make_wheel('pkg', '1.0', {
+        path = self._wheel('pkg', '1.0', {
             'real/__init__.py': '',
         }, top_level_txt='real\nbad/path\nback\\slash\n')
         inspection = inspect_wheel(path)
@@ -255,10 +246,9 @@ class TestDetectImportNames(unittest.TestCase):
         self.assertIn('real', names)
         self.assertNotIn('bad/path', names)
         self.assertNotIn('back\\slash', names)
-        os.unlink(path)
 
     def test_top_level_txt_ignores_tests(self):
-        path = _make_wheel('pkg', '1.0', {
+        path = self._wheel('pkg', '1.0', {
             'real/__init__.py': '',
             'tests/__init__.py': '',
         }, top_level_txt='real\ntests\n')
@@ -266,10 +256,9 @@ class TestDetectImportNames(unittest.TestCase):
         names = detect_import_names(inspection)
         self.assertIn('real', names)
         self.assertNotIn('tests', names)
-        os.unlink(path)
 
     def test_top_level_txt_skips_underscore_when_imports_exist(self):
-        path = _make_wheel('pkg', '1.0', {
+        path = self._wheel('pkg', '1.0', {
             'real/__init__.py': '',
             '_private/__init__.py': '',
         }, top_level_txt='real\n_private\n')
@@ -277,20 +266,18 @@ class TestDetectImportNames(unittest.TestCase):
         names = detect_import_names(inspection)
         self.assertIn('real', names)
         self.assertNotIn('_private', names)
-        os.unlink(path)
 
     def test_namespace_package(self):
-        path = _make_wheel('ns_pkg', '1.0', {
+        path = self._wheel('ns_pkg', '1.0', {
             'ns/sub/__init__.py': '',
             'ns/sub/mod.py': '',
         })
         inspection = inspect_wheel(path)
         names = detect_import_names(inspection)
         self.assertIn('ns.sub', names)
-        os.unlink(path)
 
     def test_multiple_packages(self):
-        path = _make_wheel('multi', '1.0', {
+        path = self._wheel('multi', '1.0', {
             'alpha/__init__.py': '',
             'beta/__init__.py': '',
         })
@@ -298,7 +285,6 @@ class TestDetectImportNames(unittest.TestCase):
         names = detect_import_names(inspection)
         self.assertIn('alpha', names)
         self.assertIn('beta', names)
-        os.unlink(path)
 
 
 class TestCheckImport(unittest.TestCase):
@@ -321,6 +307,11 @@ class TestCheckImport(unittest.TestCase):
 
 
 class TestMain(unittest.TestCase):
+    def _wheel(self, *args, **kwargs):
+        path = _make_wheel(*args, **kwargs)
+        self.addCleanup(lambda: os.path.exists(path) and os.unlink(path))
+        return path
+
     def _run_main(self, *args):
         """Run main() in-process, capturing stdout and SystemExit."""
         with patch('sys.argv', ['verify_import.py'] + list(args)):
@@ -332,31 +323,29 @@ class TestMain(unittest.TestCase):
                     return e.code, mock_out.getvalue()
 
     def test_classify_only_importable(self):
-        path = _make_wheel('clstest', '1.0', {'clstest/__init__.py': ''})
+        path = self._wheel('clstest', '1.0', {'clstest/__init__.py': ''})
         rc, _ = self._run_main('--classify-only', path)
         self.assertEqual(rc, 10)
-        os.unlink(path)
 
     def test_classify_only_empty(self):
-        path = _make_wheel('emptytest', '1.0', {})
+        path = self._wheel('emptytest', '1.0', {})
         rc, out = self._run_main('--classify-only', path)
         self.assertEqual(rc, 0)
         d = json.loads(out)
         self.assertEqual(d['status'], 'SKIP')
         self.assertIn('empty', d['reason'])
-        os.unlink(path)
 
     def test_classify_only_data_only(self):
-        path = _make_wheel('datatest', '1.0', {'datatest/data.csv': 'a,b,c'})
+        path = self._wheel('datatest', '1.0', {'datatest/data.csv': 'a,b,c'})
         rc, out = self._run_main('--classify-only', path)
         self.assertEqual(rc, 0)
         d = json.loads(out)
         self.assertEqual(d['status'], 'SKIP')
         self.assertIn('data-only', d['reason'])
-        os.unlink(path)
 
     def test_missing_file(self):
-        rc, out = self._run_main('/tmp/nonexistent-wheel-12345.whl')
+        with tempfile.TemporaryDirectory() as td:
+            rc, out = self._run_main(os.path.join(td, 'nonexistent.whl'))
         self.assertEqual(rc, 2)
         d = json.loads(out)
         self.assertEqual(d['status'], 'ERROR')
@@ -366,17 +355,16 @@ class TestMain(unittest.TestCase):
         self.assertEqual(rc, 2)
 
     def test_import_pass(self):
-        path = _make_wheel('jsonwrap', '1.0', {'json_wrap/__init__.py': ''})
+        path = self._wheel('jsonwrap', '1.0', {'json_wrap/__init__.py': ''})
         rc, out = self._run_main(path)
         d = json.loads(out)
-        self.assertIn(d['status'], ('PASS', 'FAIL'))
         self.assertEqual(d['wheel'], os.path.basename(path))
         self.assertIn('dist_name', d)
         self.assertIn('version', d)
-        os.unlink(path)
+        self.assertIn('imports_tested', d)
 
     def test_import_fail(self):
-        path = _make_wheel('xyznonexist', '1.0', {
+        path = self._wheel('xyznonexist', '1.0', {
             'xyznonexist_pkg/__init__.py': 'import nonexistent_module_abc_999',
         })
         rc, out = self._run_main(path)
@@ -384,24 +372,22 @@ class TestMain(unittest.TestCase):
         self.assertEqual(d['status'], 'FAIL')
         self.assertEqual(rc, 1)
         self.assertTrue(any(not t['success'] for t in d['imports_tested']))
-        os.unlink(path)
 
-    def test_no_import_names_detected(self):
-        path = _make_wheel('odd', '1.0', {'_only_private/__init__.py': ''})
+    def test_private_only_imports(self):
+        path = self._wheel('odd', '1.0', {'_only_private/__init__.py': ''})
         rc, out = self._run_main(path)
         d = json.loads(out)
-        self.assertIn(d['status'], ('PASS', 'FAIL'))
-        os.unlink(path)
+        self.assertIn('imports_tested', d)
 
     def test_no_dist_info(self):
         fd, path = tempfile.mkstemp(suffix='.whl')
         os.close(fd)
+        self.addCleanup(lambda: os.path.exists(path) and os.unlink(path))
         with zipfile.ZipFile(path, 'w') as zf:
             zf.writestr('pkg/__init__.py', '')
         rc, out = self._run_main(path)
         d = json.loads(out)
         self.assertEqual(d['dist_name'], 'unknown')
-        os.unlink(path)
 
 
 if __name__ == '__main__':

--- a/tasks/scripts/wheel-check/test_wheel_helpers.py
+++ b/tasks/scripts/wheel-check/test_wheel_helpers.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import io
 import json
 import os
 import subprocess
@@ -6,6 +7,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from wheel_helpers import (
@@ -16,6 +18,7 @@ from wheel_helpers import (
     group_has_built,
     lookup_primary,
     lookup_wheel,
+    match_installed_wheels,
     normalize,
     print_failed_imports,
     read_built_status,
@@ -56,22 +59,28 @@ class TestReadResultStatus(unittest.TestCase):
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
             json.dump({'status': 'PASS'}, f)
             f.flush()
+        try:
             self.assertEqual(read_result_status(f.name), 'PASS')
-        os.unlink(f.name)
+        finally:
+            os.unlink(f.name)
 
     def test_fail(self):
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
             json.dump({'status': 'FAIL'}, f)
             f.flush()
+        try:
             self.assertEqual(read_result_status(f.name), 'FAIL')
-        os.unlink(f.name)
+        finally:
+            os.unlink(f.name)
 
     def test_missing_status(self):
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
             json.dump({}, f)
             f.flush()
+        try:
             self.assertEqual(read_result_status(f.name), 'FAIL')
-        os.unlink(f.name)
+        finally:
+            os.unlink(f.name)
 
     def test_missing_file(self):
         self.assertEqual(read_result_status('/tmp/nonexistent-file-12345.json'), 'FAIL')
@@ -80,8 +89,10 @@ class TestReadResultStatus(unittest.TestCase):
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
             f.write('not json')
             f.flush()
+        try:
             self.assertEqual(read_result_status(f.name), 'FAIL')
-        os.unlink(f.name)
+        finally:
+            os.unlink(f.name)
 
 
 class TestReadField(unittest.TestCase):
@@ -89,22 +100,26 @@ class TestReadField(unittest.TestCase):
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
             json.dump({'wheel': 'foo-1.0.whl', 'status': 'PASS'}, f)
             f.flush()
+        try:
             self.assertEqual(read_field(f.name, 'wheel'), 'foo-1.0.whl')
-        os.unlink(f.name)
+        finally:
+            os.unlink(f.name)
 
     def test_missing_field(self):
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
             json.dump({'status': 'PASS'}, f)
             f.flush()
+        try:
             self.assertEqual(read_field(f.name, 'undeclared_dep'), '')
-        os.unlink(f.name)
+        finally:
+            os.unlink(f.name)
 
     def test_missing_file(self):
         self.assertEqual(read_field('/tmp/nonexistent-file-12345.json', 'status'), '')
 
 
 class TestPrintFailedImports(unittest.TestCase):
-    def test_prints_failures(self, ):
+    def test_prints_failures(self):
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
             json.dump({
                 'imports_tested': [
@@ -113,37 +128,37 @@ class TestPrintFailedImports(unittest.TestCase):
                 ]
             }, f)
             f.flush()
-            import io
-            from unittest.mock import patch
+        try:
             with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
                 print_failed_imports(f.name, prefix='  -> ')
                 output = mock_out.getvalue()
             self.assertIn('bar', output)
             self.assertIn('  -> ', output)
             self.assertNotIn('foo', output)
-        os.unlink(f.name)
+        finally:
+            os.unlink(f.name)
 
     def test_no_failures(self):
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
             json.dump({'imports_tested': [{'name': 'foo', 'success': True}]}, f)
             f.flush()
-            import io
-            from unittest.mock import patch
+        try:
             with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
                 print_failed_imports(f.name)
                 self.assertEqual(mock_out.getvalue(), '')
-        os.unlink(f.name)
+        finally:
+            os.unlink(f.name)
 
     def test_corrupt_file(self):
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
             f.write('not json')
             f.flush()
-            import io
-            from unittest.mock import patch
+        try:
             with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
                 print_failed_imports(f.name)
                 self.assertEqual(mock_out.getvalue(), '')
-        os.unlink(f.name)
+        finally:
+            os.unlink(f.name)
 
 
 class TestFormatSummaryRow(unittest.TestCase):
@@ -151,28 +166,26 @@ class TestFormatSummaryRow(unittest.TestCase):
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
             json.dump({'wheel': 'foo-1.0.whl', 'status': 'PASS', 'reason': ''}, f)
             f.flush()
-            import io
-            from unittest.mock import patch
+        try:
             with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
                 format_summary_row(f.name)
                 self.assertIn('PASS', mock_out.getvalue())
                 self.assertIn('foo-1.0.whl', mock_out.getvalue())
-        os.unlink(f.name)
+        finally:
+            os.unlink(f.name)
 
     def test_with_undeclared_dep(self):
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
             json.dump({'wheel': 'foo-1.0.whl', 'status': 'PASS', 'reason': '', 'undeclared_dep': 'bar'}, f)
             f.flush()
-            import io
-            from unittest.mock import patch
+        try:
             with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
                 format_summary_row(f.name)
                 self.assertIn('undeclared dep: bar', mock_out.getvalue())
-        os.unlink(f.name)
+        finally:
+            os.unlink(f.name)
 
     def test_invalid_file(self):
-        import io
-        from unittest.mock import patch
         with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
             format_summary_row('/tmp/nonexistent-12345.json')
             output = mock_out.getvalue()
@@ -186,11 +199,13 @@ class TestAnnotateDep(unittest.TestCase):
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
             json.dump({'status': 'PASS'}, f)
             f.flush()
+        try:
             annotate_dep(f.name, 'click')
             with open(f.name) as rf:
                 d = json.load(rf)
             self.assertEqual(d['undeclared_dep'], 'click')
-        os.unlink(f.name)
+        finally:
+            os.unlink(f.name)
 
 
 class TestLookupWheel(unittest.TestCase):
@@ -198,23 +213,23 @@ class TestLookupWheel(unittest.TestCase):
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
             json.dump({'click-8.1.0': 'click-8.1.0-py3-none-any.whl'}, f)
             f.flush()
-            import io
-            from unittest.mock import patch
+        try:
             with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
                 lookup_wheel(f.name, 'click', '8.1.0')
                 self.assertEqual(mock_out.getvalue().strip(), 'click-8.1.0-py3-none-any.whl')
-        os.unlink(f.name)
+        finally:
+            os.unlink(f.name)
 
     def test_not_found(self):
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
             json.dump({}, f)
             f.flush()
-            import io
-            from unittest.mock import patch
+        try:
             with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
                 lookup_wheel(f.name, 'nonexistent', '1.0')
                 self.assertEqual(mock_out.getvalue().strip(), '')
-        os.unlink(f.name)
+        finally:
+            os.unlink(f.name)
 
 
 class TestExtractMissingModule(unittest.TestCase):
@@ -226,12 +241,12 @@ class TestExtractMissingModule(unittest.TestCase):
                 ]
             }, f)
             f.flush()
-            import io
-            from unittest.mock import patch
+        try:
             with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
                 extract_missing_module(f.name)
                 self.assertEqual(mock_out.getvalue().strip(), 'click')
-        os.unlink(f.name)
+        finally:
+            os.unlink(f.name)
 
     def test_dotted_module(self):
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
@@ -241,40 +256,38 @@ class TestExtractMissingModule(unittest.TestCase):
                 ]
             }, f)
             f.flush()
-            import io
-            from unittest.mock import patch
+        try:
             with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
                 extract_missing_module(f.name)
                 self.assertEqual(mock_out.getvalue().strip(), 'pkg')
-        os.unlink(f.name)
+        finally:
+            os.unlink(f.name)
 
     def test_no_missing(self):
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
             json.dump({'imports_tested': [{'name': 'foo', 'success': True}]}, f)
             f.flush()
-            import io
-            from unittest.mock import patch
+        try:
             with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
                 extract_missing_module(f.name)
                 self.assertEqual(mock_out.getvalue().strip(), '')
-        os.unlink(f.name)
+        finally:
+            os.unlink(f.name)
 
     def test_corrupt_file(self):
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
             f.write('not json')
             f.flush()
-            import io
-            from unittest.mock import patch
+        try:
             with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
                 extract_missing_module(f.name)
                 self.assertEqual(mock_out.getvalue().strip(), '')
-        os.unlink(f.name)
+        finally:
+            os.unlink(f.name)
 
 
 class TestWriteFailureResult(unittest.TestCase):
     def test_output(self):
-        import io
-        from unittest.mock import patch
         with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
             write_failure_result('foo-1.0.whl', 'pip install failed')
             d = json.loads(mock_out.getvalue())
@@ -285,29 +298,29 @@ class TestWriteFailureResult(unittest.TestCase):
 
 class TestLookupPrimary(unittest.TestCase):
     def _make_files(self, summary_entries, wheel_index):
-        summary_file = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False)
-        json.dump(summary_entries, summary_file)
-        summary_file.flush()
-        index_file = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False)
-        json.dump(wheel_index, index_file)
-        index_file.flush()
-        return summary_file.name, index_file.name
+        sf = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False)
+        json.dump(summary_entries, sf)
+        sf.flush()
+        sf.close()
+        wf = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False)
+        json.dump(wheel_index, wf)
+        wf.flush()
+        wf.close()
+        self.addCleanup(lambda: os.unlink(sf.name) if os.path.exists(sf.name) else None)
+        self.addCleanup(lambda: os.unlink(wf.name) if os.path.exists(wf.name) else None)
+        return sf.name, wf.name
 
     def test_normal_label(self):
         summary_path, index_path = self._make_files(
             [{'name': 'click', 'version': '8.1.0'}],
             {'click-8.1.0': 'click-8.1.0-0-py3-none-any.whl'},
         )
-        import io
-        from unittest.mock import patch
         with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
             lookup_primary('click__8.1.0', summary_path, index_path)
             lines = mock_out.getvalue().strip().split('\n')
             self.assertEqual(lines[0], 'click')
             self.assertEqual(lines[1], '8.1.0')
             self.assertEqual(lines[2], 'click-8.1.0-0-py3-none-any.whl')
-        os.unlink(summary_path)
-        os.unlink(index_path)
 
     def test_git_sourced_label(self):
         summary_path, index_path = self._make_files(
@@ -317,8 +330,6 @@ class TestLookupPrimary(unittest.TestCase):
             ],
             {'presidio_analyzer-2.2.359': 'presidio_analyzer-2.2.359-0-py3-none-any.whl'},
         )
-        import io
-        from unittest.mock import patch
         label = 'presidio_analyzer___git_https___github.com_microsoft_presidio.git_2.2.359'
         with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
             lookup_primary(label, summary_path, index_path)
@@ -326,46 +337,32 @@ class TestLookupPrimary(unittest.TestCase):
             self.assertEqual(lines[0], 'presidio-analyzer')
             self.assertEqual(lines[1], '2.2.359')
             self.assertEqual(lines[2], 'presidio_analyzer-2.2.359-0-py3-none-any.whl')
-        os.unlink(summary_path)
-        os.unlink(index_path)
 
     def test_hyphenated_name(self):
         summary_path, index_path = self._make_files(
             [{'name': 'pydantic-ai-slim', 'version': '2.10.0'}],
             {'pydantic_ai_slim-2.10.0': 'pydantic_ai_slim-2.10.0-0-py3-none-any.whl'},
         )
-        import io
-        from unittest.mock import patch
         with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
             lookup_primary('pydantic-ai-slim__2.10.0', summary_path, index_path)
             lines = mock_out.getvalue().strip().split('\n')
             self.assertEqual(lines[0], 'pydantic-ai-slim')
             self.assertEqual(lines[1], '2.10.0')
-        os.unlink(summary_path)
-        os.unlink(index_path)
 
     def test_no_match(self):
         summary_path, index_path = self._make_files(
             [{'name': 'other-pkg', 'version': '1.0'}],
             {},
         )
-        import io
-        from unittest.mock import patch
         with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
             lookup_primary('click__8.1.0', summary_path, index_path)
             self.assertEqual(mock_out.getvalue().strip(), '')
-        os.unlink(summary_path)
-        os.unlink(index_path)
 
     def test_empty_summary(self):
         summary_path, index_path = self._make_files([], {})
-        import io
-        from unittest.mock import patch
         with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
             lookup_primary('click__8.1.0', summary_path, index_path)
             self.assertEqual(mock_out.getvalue().strip(), '')
-        os.unlink(summary_path)
-        os.unlink(index_path)
 
     def test_no_prefix_collision(self):
         summary_path, index_path = self._make_files(
@@ -375,15 +372,11 @@ class TestLookupPrimary(unittest.TestCase):
             ],
             {'foobar-2.0': 'foobar-2.0-0-py3-none-any.whl'},
         )
-        import io
-        from unittest.mock import patch
         with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
             lookup_primary('foobar__2.0', summary_path, index_path)
             lines = mock_out.getvalue().strip().split('\n')
             self.assertEqual(lines[0], 'foobar')
             self.assertEqual(lines[1], '2.0')
-        os.unlink(summary_path)
-        os.unlink(index_path)
 
 
 class TestFindMissingWheel(unittest.TestCase):
@@ -391,34 +384,34 @@ class TestFindMissingWheel(unittest.TestCase):
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
             json.dump({'click': ['click-8.1.0-py3-none-any.whl']}, f)
             f.flush()
-            import io
-            from unittest.mock import patch
+        try:
             with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
                 find_missing_wheel('click', '', f.name)
                 self.assertEqual(mock_out.getvalue().strip(), 'click-8.1.0-py3-none-any.whl')
-        os.unlink(f.name)
+        finally:
+            os.unlink(f.name)
 
     def test_skips_tried(self):
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
             json.dump({'click': ['click-8.1.0-py3-none-any.whl']}, f)
             f.flush()
-            import io
-            from unittest.mock import patch
+        try:
             with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
                 find_missing_wheel('click', 'click-8.1.0-py3-none-any.whl', f.name)
                 self.assertEqual(mock_out.getvalue().strip(), '')
-        os.unlink(f.name)
+        finally:
+            os.unlink(f.name)
 
     def test_corrupt_import_map(self):
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
             f.write('not json')
             f.flush()
-            import io
-            from unittest.mock import patch
+        try:
             with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
                 find_missing_wheel('click', '', f.name)
                 self.assertEqual(mock_out.getvalue().strip(), '')
-        os.unlink(f.name)
+        finally:
+            os.unlink(f.name)
 
 
 class TestCLIDispatch(unittest.TestCase):
@@ -426,13 +419,15 @@ class TestCLIDispatch(unittest.TestCase):
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
             json.dump({'status': 'PASS'}, f)
             f.flush()
+        try:
             script = str(Path(__file__).resolve().parent / 'wheel_helpers.py')
             result = subprocess.run(
                 [sys.executable, script, 'read-status', f.name],
                 capture_output=True, text=True,
             )
             self.assertEqual(result.stdout.strip(), 'PASS')
-        os.unlink(f.name)
+        finally:
+            os.unlink(f.name)
 
     def test_write_failure_cli(self):
         script = str(Path(__file__).resolve().parent / 'wheel_helpers.py')
@@ -458,8 +453,6 @@ class TestCLIDispatch(unittest.TestCase):
 
 class TestWriteSkipResult(unittest.TestCase):
     def test_output(self):
-        import io
-        from unittest.mock import patch
         with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
             write_skip_result('cached.whl', 'no matching sdist')
             d = json.loads(mock_out.getvalue())
@@ -471,101 +464,165 @@ class TestWriteSkipResult(unittest.TestCase):
 
 class TestReadBuiltStatus(unittest.TestCase):
     def test_reads_status(self):
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False,
-                                          dir='/tmp', prefix='built-wheels') as f:
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
             json.dump({'status': 'has_built', 'wheels': ['a.whl']}, f)
             f.flush()
-        saved = '/tmp/built-wheels.json'
-        import shutil
-        shutil.copy(f.name, saved)
-        os.unlink(f.name)
         try:
-            self.assertEqual(read_built_status(), 'has_built')
+            self.assertEqual(read_built_status(f.name), 'has_built')
         finally:
-            os.unlink(saved)
+            os.unlink(f.name)
 
     def test_missing_file(self):
-        saved = '/tmp/built-wheels.json'
-        if os.path.exists(saved):
-            os.unlink(saved)
-        self.assertEqual(read_built_status(), 'no_sdists')
+        self.assertEqual(read_built_status('/tmp/nonexistent-built-12345.json'), 'no_sdists')
 
 
 class TestReadBuiltWheels(unittest.TestCase):
     def test_reads_wheels(self):
-        saved = '/tmp/built-wheels.json'
-        with open(saved, 'w') as f:
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
             json.dump({'status': 'has_built', 'wheels': ['a.whl', 'b.whl']}, f)
+            f.flush()
         try:
-            result = read_built_wheels()
+            result = read_built_wheels(f.name)
             self.assertIn('a.whl', result)
             self.assertIn('b.whl', result)
         finally:
-            os.unlink(saved)
+            os.unlink(f.name)
 
     def test_missing_file(self):
-        saved = '/tmp/built-wheels.json'
-        if os.path.exists(saved):
-            os.unlink(saved)
-        self.assertEqual(read_built_wheels(), '')
+        self.assertEqual(read_built_wheels('/tmp/nonexistent-built-12345.json'), '')
 
 
 class TestGroupHasBuilt(unittest.TestCase):
     def _setup(self, summary_entries, wheel_index, built_csv):
-        summary_path = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False)
-        json.dump(summary_entries, summary_path)
-        summary_path.flush()
-        with open('/tmp/wheel-index.json', 'w') as f:
-            json.dump(wheel_index, f)
-        return summary_path.name
+        sf = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False)
+        json.dump(summary_entries, sf)
+        sf.flush()
+        sf.close()
+        wf = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False)
+        json.dump(wheel_index, wf)
+        wf.flush()
+        wf.close()
+        self.addCleanup(lambda: os.unlink(sf.name) if os.path.exists(sf.name) else None)
+        self.addCleanup(lambda: os.unlink(wf.name) if os.path.exists(wf.name) else None)
+        return sf.name, wf.name
 
     def test_has_built_wheel(self):
-        summary_path = self._setup(
+        summary_path, index_path = self._setup(
             [{'name': 'click', 'version': '8.1.0'}],
             {'click-8.1.0': 'click-8.1.0-py3-none-any.whl'},
             'click-8.1.0-py3-none-any.whl',
         )
-        import io
-        from unittest.mock import patch
         with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
-            group_has_built(summary_path, 'click-8.1.0-py3-none-any.whl')
+            group_has_built(summary_path, 'click-8.1.0-py3-none-any.whl',
+                            wheel_index_path=index_path)
             self.assertEqual(mock_out.getvalue().strip(), 'yes')
-        os.unlink(summary_path)
 
     def test_no_built_wheel(self):
-        summary_path = self._setup(
+        summary_path, index_path = self._setup(
             [{'name': 'click', 'version': '8.1.0'}],
             {'click-8.1.0': 'click-8.1.0-py3-none-any.whl'},
             'other.whl',
         )
-        import io
-        from unittest.mock import patch
         with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
-            group_has_built(summary_path, 'other.whl')
+            group_has_built(summary_path, 'other.whl',
+                            wheel_index_path=index_path)
             self.assertEqual(mock_out.getvalue().strip(), 'no')
-        os.unlink(summary_path)
 
     def test_empty_summary(self):
-        summary_path = self._setup([], {}, '')
-        import io
-        from unittest.mock import patch
+        summary_path, index_path = self._setup([], {}, '')
         with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
-            group_has_built(summary_path, 'any.whl')
+            group_has_built(summary_path, 'any.whl',
+                            wheel_index_path=index_path)
             self.assertEqual(mock_out.getvalue().strip(), 'no')
-        os.unlink(summary_path)
 
     def test_corrupt_json_warns(self):
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
             f.write('not json')
             f.flush()
-        import io
-        from unittest.mock import patch
-        with patch('sys.stdout', new_callable=io.StringIO) as mock_out, \
-             patch('sys.stderr', new_callable=io.StringIO) as mock_err:
-            group_has_built(f.name, 'any.whl')
+        try:
+            with patch('sys.stdout', new_callable=io.StringIO) as mock_out, \
+                 patch('sys.stderr', new_callable=io.StringIO) as mock_err:
+                group_has_built(f.name, 'any.whl')
+                self.assertEqual(mock_out.getvalue().strip(), 'no')
+                self.assertIn('WARNING', mock_err.getvalue())
+        finally:
+            os.unlink(f.name)
+
+    def test_empty_csv_no_false_positive(self):
+        summary_path, index_path = self._setup(
+            [{'name': 'click', 'version': '8.1.0'}],
+            {'click-8.1.0': 'click-8.1.0-py3-none-any.whl'},
+            '',
+        )
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
+            group_has_built(summary_path, '',
+                            wheel_index_path=index_path)
             self.assertEqual(mock_out.getvalue().strip(), 'no')
-            self.assertIn('WARNING', mock_err.getvalue())
-        os.unlink(f.name)
+
+
+class TestMatchInstalledWheels(unittest.TestCase):
+    def test_matches_installed(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump({
+                'click-8.1.0': 'click-8.1.0-py3-none-any.whl',
+                'flask-3.0.0': 'flask-3.0.0-py3-none-any.whl',
+            }, f)
+            f.flush()
+        try:
+            stdin_data = json.dumps([
+                {'name': 'click', 'version': '8.1.0'},
+                {'name': 'requests', 'version': '2.31.0'},
+            ])
+            with patch('sys.stdin', io.StringIO(stdin_data)), \
+                 patch('sys.stdout', new_callable=io.StringIO) as mock_out:
+                match_installed_wheels(f.name)
+                self.assertEqual(mock_out.getvalue().strip(), 'click-8.1.0-py3-none-any.whl')
+        finally:
+            os.unlink(f.name)
+
+    def test_no_matches(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump({'click-8.1.0': 'click-8.1.0-py3-none-any.whl'}, f)
+            f.flush()
+        try:
+            stdin_data = json.dumps([{'name': 'requests', 'version': '2.31.0'}])
+            with patch('sys.stdin', io.StringIO(stdin_data)), \
+                 patch('sys.stdout', new_callable=io.StringIO) as mock_out:
+                match_installed_wheels(f.name)
+                self.assertEqual(mock_out.getvalue().strip(), '')
+        finally:
+            os.unlink(f.name)
+
+
+class TestFindMissingWheelFallback(unittest.TestCase):
+    def test_cwd_fallback(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(os.path.join(tmpdir, 'click-8.1.0-py3-none-any.whl')).touch()
+            with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+                json.dump({}, f)
+                f.flush()
+            try:
+                with patch('sys.stdout', new_callable=io.StringIO) as mock_out, \
+                     patch('wheel_helpers.os.listdir', return_value=os.listdir(tmpdir)):
+                    find_missing_wheel('click', '', f.name)
+                    self.assertEqual(mock_out.getvalue().strip(),
+                                     'click-8.1.0-py3-none-any.whl')
+            finally:
+                os.unlink(f.name)
+
+    def test_cwd_fallback_skips_tried(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(os.path.join(tmpdir, 'click-8.1.0-py3-none-any.whl')).touch()
+            with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+                json.dump({}, f)
+                f.flush()
+            try:
+                with patch('sys.stdout', new_callable=io.StringIO) as mock_out, \
+                     patch('wheel_helpers.os.listdir', return_value=os.listdir(tmpdir)):
+                    find_missing_wheel('click', 'click-8.1.0-py3-none-any.whl', f.name)
+                    self.assertEqual(mock_out.getvalue().strip(), '')
+            finally:
+                os.unlink(f.name)
 
 
 if __name__ == '__main__':

--- a/tasks/scripts/wheel-check/test_wheel_helpers.py
+++ b/tasks/scripts/wheel-check/test_wheel_helpers.py
@@ -1,0 +1,572 @@
+#!/usr/bin/env python3
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from wheel_helpers import (
+    annotate_dep,
+    extract_missing_module,
+    find_missing_wheel,
+    format_summary_row,
+    group_has_built,
+    lookup_primary,
+    lookup_wheel,
+    normalize,
+    print_failed_imports,
+    read_built_status,
+    read_built_wheels,
+    read_field,
+    read_result_status,
+    write_failure_result,
+    write_skip_result,
+)
+
+
+class TestNormalize(unittest.TestCase):
+    def test_hyphen(self):
+        self.assertEqual(normalize("my-package"), "my_package")
+
+    def test_dot(self):
+        self.assertEqual(normalize("my.package"), "my_package")
+
+    def test_underscore(self):
+        self.assertEqual(normalize("my_package"), "my_package")
+
+    def test_mixed(self):
+        self.assertEqual(normalize("My-Package.Name"), "my_package_name")
+
+    def test_consecutive_separators(self):
+        self.assertEqual(normalize("foo--bar"), "foo_bar")
+
+    def test_case(self):
+        self.assertEqual(normalize("MyPackage"), "mypackage")
+
+    def test_pep503_equivalence(self):
+        self.assertEqual(normalize("Foo-Bar"), normalize("foo_bar"))
+        self.assertEqual(normalize("foo.bar"), normalize("foo-bar"))
+
+
+class TestReadResultStatus(unittest.TestCase):
+    def test_pass(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump({'status': 'PASS'}, f)
+            f.flush()
+            self.assertEqual(read_result_status(f.name), 'PASS')
+        os.unlink(f.name)
+
+    def test_fail(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump({'status': 'FAIL'}, f)
+            f.flush()
+            self.assertEqual(read_result_status(f.name), 'FAIL')
+        os.unlink(f.name)
+
+    def test_missing_status(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump({}, f)
+            f.flush()
+            self.assertEqual(read_result_status(f.name), 'FAIL')
+        os.unlink(f.name)
+
+    def test_missing_file(self):
+        self.assertEqual(read_result_status('/tmp/nonexistent-file-12345.json'), 'FAIL')
+
+    def test_invalid_json(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            f.write('not json')
+            f.flush()
+            self.assertEqual(read_result_status(f.name), 'FAIL')
+        os.unlink(f.name)
+
+
+class TestReadField(unittest.TestCase):
+    def test_existing_field(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump({'wheel': 'foo-1.0.whl', 'status': 'PASS'}, f)
+            f.flush()
+            self.assertEqual(read_field(f.name, 'wheel'), 'foo-1.0.whl')
+        os.unlink(f.name)
+
+    def test_missing_field(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump({'status': 'PASS'}, f)
+            f.flush()
+            self.assertEqual(read_field(f.name, 'undeclared_dep'), '')
+        os.unlink(f.name)
+
+    def test_missing_file(self):
+        self.assertEqual(read_field('/tmp/nonexistent-file-12345.json', 'status'), '')
+
+
+class TestPrintFailedImports(unittest.TestCase):
+    def test_prints_failures(self, ):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump({
+                'imports_tested': [
+                    {'name': 'foo', 'success': True, 'message': 'OK'},
+                    {'name': 'bar', 'success': False, 'message': 'ImportError: No module named bar'},
+                ]
+            }, f)
+            f.flush()
+            import io
+            from unittest.mock import patch
+            with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
+                print_failed_imports(f.name, prefix='  -> ')
+                output = mock_out.getvalue()
+            self.assertIn('bar', output)
+            self.assertIn('  -> ', output)
+            self.assertNotIn('foo', output)
+        os.unlink(f.name)
+
+    def test_no_failures(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump({'imports_tested': [{'name': 'foo', 'success': True}]}, f)
+            f.flush()
+            import io
+            from unittest.mock import patch
+            with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
+                print_failed_imports(f.name)
+                self.assertEqual(mock_out.getvalue(), '')
+        os.unlink(f.name)
+
+    def test_corrupt_file(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            f.write('not json')
+            f.flush()
+            import io
+            from unittest.mock import patch
+            with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
+                print_failed_imports(f.name)
+                self.assertEqual(mock_out.getvalue(), '')
+        os.unlink(f.name)
+
+
+class TestFormatSummaryRow(unittest.TestCase):
+    def test_pass(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump({'wheel': 'foo-1.0.whl', 'status': 'PASS', 'reason': ''}, f)
+            f.flush()
+            import io
+            from unittest.mock import patch
+            with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
+                format_summary_row(f.name)
+                self.assertIn('PASS', mock_out.getvalue())
+                self.assertIn('foo-1.0.whl', mock_out.getvalue())
+        os.unlink(f.name)
+
+    def test_with_undeclared_dep(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump({'wheel': 'foo-1.0.whl', 'status': 'PASS', 'reason': '', 'undeclared_dep': 'bar'}, f)
+            f.flush()
+            import io
+            from unittest.mock import patch
+            with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
+                format_summary_row(f.name)
+                self.assertIn('undeclared dep: bar', mock_out.getvalue())
+        os.unlink(f.name)
+
+    def test_invalid_file(self):
+        import io
+        from unittest.mock import patch
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
+            format_summary_row('/tmp/nonexistent-12345.json')
+            output = mock_out.getvalue()
+            self.assertIn('FAIL', output)
+            self.assertIn('nonexistent-12345', output)
+            self.assertIn('verify_import failed without output', output)
+
+
+class TestAnnotateDep(unittest.TestCase):
+    def test_adds_dep(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump({'status': 'PASS'}, f)
+            f.flush()
+            annotate_dep(f.name, 'click')
+            with open(f.name) as rf:
+                d = json.load(rf)
+            self.assertEqual(d['undeclared_dep'], 'click')
+        os.unlink(f.name)
+
+
+class TestLookupWheel(unittest.TestCase):
+    def test_found(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump({'click-8.1.0': 'click-8.1.0-py3-none-any.whl'}, f)
+            f.flush()
+            import io
+            from unittest.mock import patch
+            with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
+                lookup_wheel(f.name, 'click', '8.1.0')
+                self.assertEqual(mock_out.getvalue().strip(), 'click-8.1.0-py3-none-any.whl')
+        os.unlink(f.name)
+
+    def test_not_found(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump({}, f)
+            f.flush()
+            import io
+            from unittest.mock import patch
+            with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
+                lookup_wheel(f.name, 'nonexistent', '1.0')
+                self.assertEqual(mock_out.getvalue().strip(), '')
+        os.unlink(f.name)
+
+
+class TestExtractMissingModule(unittest.TestCase):
+    def test_extracts_module(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump({
+                'imports_tested': [
+                    {'name': 'foo', 'success': False, 'message': "ImportError: No module named 'click'"},
+                ]
+            }, f)
+            f.flush()
+            import io
+            from unittest.mock import patch
+            with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
+                extract_missing_module(f.name)
+                self.assertEqual(mock_out.getvalue().strip(), 'click')
+        os.unlink(f.name)
+
+    def test_dotted_module(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump({
+                'imports_tested': [
+                    {'name': 'foo', 'success': False, 'message': "ImportError: No module named 'pkg.sub'"},
+                ]
+            }, f)
+            f.flush()
+            import io
+            from unittest.mock import patch
+            with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
+                extract_missing_module(f.name)
+                self.assertEqual(mock_out.getvalue().strip(), 'pkg')
+        os.unlink(f.name)
+
+    def test_no_missing(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump({'imports_tested': [{'name': 'foo', 'success': True}]}, f)
+            f.flush()
+            import io
+            from unittest.mock import patch
+            with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
+                extract_missing_module(f.name)
+                self.assertEqual(mock_out.getvalue().strip(), '')
+        os.unlink(f.name)
+
+    def test_corrupt_file(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            f.write('not json')
+            f.flush()
+            import io
+            from unittest.mock import patch
+            with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
+                extract_missing_module(f.name)
+                self.assertEqual(mock_out.getvalue().strip(), '')
+        os.unlink(f.name)
+
+
+class TestWriteFailureResult(unittest.TestCase):
+    def test_output(self):
+        import io
+        from unittest.mock import patch
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
+            write_failure_result('foo-1.0.whl', 'pip install failed')
+            d = json.loads(mock_out.getvalue())
+            self.assertEqual(d['wheel'], 'foo-1.0.whl')
+            self.assertEqual(d['status'], 'FAIL')
+            self.assertEqual(d['reason'], 'pip install failed')
+
+
+class TestLookupPrimary(unittest.TestCase):
+    def _make_files(self, summary_entries, wheel_index):
+        summary_file = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False)
+        json.dump(summary_entries, summary_file)
+        summary_file.flush()
+        index_file = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False)
+        json.dump(wheel_index, index_file)
+        index_file.flush()
+        return summary_file.name, index_file.name
+
+    def test_normal_label(self):
+        summary_path, index_path = self._make_files(
+            [{'name': 'click', 'version': '8.1.0'}],
+            {'click-8.1.0': 'click-8.1.0-0-py3-none-any.whl'},
+        )
+        import io
+        from unittest.mock import patch
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
+            lookup_primary('click__8.1.0', summary_path, index_path)
+            lines = mock_out.getvalue().strip().split('\n')
+            self.assertEqual(lines[0], 'click')
+            self.assertEqual(lines[1], '8.1.0')
+            self.assertEqual(lines[2], 'click-8.1.0-0-py3-none-any.whl')
+        os.unlink(summary_path)
+        os.unlink(index_path)
+
+    def test_git_sourced_label(self):
+        summary_path, index_path = self._make_files(
+            [
+                {'name': 'presidio-analyzer', 'version': '2.2.359'},
+                {'name': 'spacy', 'version': '3.8.13'},
+            ],
+            {'presidio_analyzer-2.2.359': 'presidio_analyzer-2.2.359-0-py3-none-any.whl'},
+        )
+        import io
+        from unittest.mock import patch
+        label = 'presidio_analyzer___git_https___github.com_microsoft_presidio.git_2.2.359'
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
+            lookup_primary(label, summary_path, index_path)
+            lines = mock_out.getvalue().strip().split('\n')
+            self.assertEqual(lines[0], 'presidio-analyzer')
+            self.assertEqual(lines[1], '2.2.359')
+            self.assertEqual(lines[2], 'presidio_analyzer-2.2.359-0-py3-none-any.whl')
+        os.unlink(summary_path)
+        os.unlink(index_path)
+
+    def test_hyphenated_name(self):
+        summary_path, index_path = self._make_files(
+            [{'name': 'pydantic-ai-slim', 'version': '2.10.0'}],
+            {'pydantic_ai_slim-2.10.0': 'pydantic_ai_slim-2.10.0-0-py3-none-any.whl'},
+        )
+        import io
+        from unittest.mock import patch
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
+            lookup_primary('pydantic-ai-slim__2.10.0', summary_path, index_path)
+            lines = mock_out.getvalue().strip().split('\n')
+            self.assertEqual(lines[0], 'pydantic-ai-slim')
+            self.assertEqual(lines[1], '2.10.0')
+        os.unlink(summary_path)
+        os.unlink(index_path)
+
+    def test_no_match(self):
+        summary_path, index_path = self._make_files(
+            [{'name': 'other-pkg', 'version': '1.0'}],
+            {},
+        )
+        import io
+        from unittest.mock import patch
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
+            lookup_primary('click__8.1.0', summary_path, index_path)
+            self.assertEqual(mock_out.getvalue().strip(), '')
+        os.unlink(summary_path)
+        os.unlink(index_path)
+
+    def test_empty_summary(self):
+        summary_path, index_path = self._make_files([], {})
+        import io
+        from unittest.mock import patch
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
+            lookup_primary('click__8.1.0', summary_path, index_path)
+            self.assertEqual(mock_out.getvalue().strip(), '')
+        os.unlink(summary_path)
+        os.unlink(index_path)
+
+    def test_no_prefix_collision(self):
+        summary_path, index_path = self._make_files(
+            [
+                {'name': 'foo', 'version': '1.0'},
+                {'name': 'foobar', 'version': '2.0'},
+            ],
+            {'foobar-2.0': 'foobar-2.0-0-py3-none-any.whl'},
+        )
+        import io
+        from unittest.mock import patch
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
+            lookup_primary('foobar__2.0', summary_path, index_path)
+            lines = mock_out.getvalue().strip().split('\n')
+            self.assertEqual(lines[0], 'foobar')
+            self.assertEqual(lines[1], '2.0')
+        os.unlink(summary_path)
+        os.unlink(index_path)
+
+
+class TestFindMissingWheel(unittest.TestCase):
+    def test_from_import_map(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump({'click': ['click-8.1.0-py3-none-any.whl']}, f)
+            f.flush()
+            import io
+            from unittest.mock import patch
+            with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
+                find_missing_wheel('click', '', f.name)
+                self.assertEqual(mock_out.getvalue().strip(), 'click-8.1.0-py3-none-any.whl')
+        os.unlink(f.name)
+
+    def test_skips_tried(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump({'click': ['click-8.1.0-py3-none-any.whl']}, f)
+            f.flush()
+            import io
+            from unittest.mock import patch
+            with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
+                find_missing_wheel('click', 'click-8.1.0-py3-none-any.whl', f.name)
+                self.assertEqual(mock_out.getvalue().strip(), '')
+        os.unlink(f.name)
+
+    def test_corrupt_import_map(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            f.write('not json')
+            f.flush()
+            import io
+            from unittest.mock import patch
+            with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
+                find_missing_wheel('click', '', f.name)
+                self.assertEqual(mock_out.getvalue().strip(), '')
+        os.unlink(f.name)
+
+
+class TestCLIDispatch(unittest.TestCase):
+    def test_read_status_cli(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump({'status': 'PASS'}, f)
+            f.flush()
+            script = str(Path(__file__).resolve().parent / 'wheel_helpers.py')
+            result = subprocess.run(
+                [sys.executable, script, 'read-status', f.name],
+                capture_output=True, text=True,
+            )
+            self.assertEqual(result.stdout.strip(), 'PASS')
+        os.unlink(f.name)
+
+    def test_write_failure_cli(self):
+        script = str(Path(__file__).resolve().parent / 'wheel_helpers.py')
+        result = subprocess.run(
+            [sys.executable, script, 'write-failure', 'test.whl', 'broken'],
+            capture_output=True, text=True,
+        )
+        d = json.loads(result.stdout)
+        self.assertEqual(d['status'], 'FAIL')
+        self.assertEqual(d['wheel'], 'test.whl')
+
+    def test_write_skip_cli(self):
+        script = str(Path(__file__).resolve().parent / 'wheel_helpers.py')
+        result = subprocess.run(
+            [sys.executable, script, 'write-skip', 'cached.whl', 'no sdist'],
+            capture_output=True, text=True,
+        )
+        d = json.loads(result.stdout)
+        self.assertEqual(d['status'], 'SKIP')
+        self.assertEqual(d['wheel'], 'cached.whl')
+        self.assertEqual(d['reason'], 'no sdist')
+
+
+class TestWriteSkipResult(unittest.TestCase):
+    def test_output(self):
+        import io
+        from unittest.mock import patch
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
+            write_skip_result('cached.whl', 'no matching sdist')
+            d = json.loads(mock_out.getvalue())
+            self.assertEqual(d['status'], 'SKIP')
+            self.assertEqual(d['wheel'], 'cached.whl')
+            self.assertEqual(d['reason'], 'no matching sdist')
+            self.assertEqual(d['imports_tested'], [])
+
+
+class TestReadBuiltStatus(unittest.TestCase):
+    def test_reads_status(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False,
+                                          dir='/tmp', prefix='built-wheels') as f:
+            json.dump({'status': 'has_built', 'wheels': ['a.whl']}, f)
+            f.flush()
+        saved = '/tmp/built-wheels.json'
+        import shutil
+        shutil.copy(f.name, saved)
+        os.unlink(f.name)
+        try:
+            self.assertEqual(read_built_status(), 'has_built')
+        finally:
+            os.unlink(saved)
+
+    def test_missing_file(self):
+        saved = '/tmp/built-wheels.json'
+        if os.path.exists(saved):
+            os.unlink(saved)
+        self.assertEqual(read_built_status(), 'no_sdists')
+
+
+class TestReadBuiltWheels(unittest.TestCase):
+    def test_reads_wheels(self):
+        saved = '/tmp/built-wheels.json'
+        with open(saved, 'w') as f:
+            json.dump({'status': 'has_built', 'wheels': ['a.whl', 'b.whl']}, f)
+        try:
+            result = read_built_wheels()
+            self.assertIn('a.whl', result)
+            self.assertIn('b.whl', result)
+        finally:
+            os.unlink(saved)
+
+    def test_missing_file(self):
+        saved = '/tmp/built-wheels.json'
+        if os.path.exists(saved):
+            os.unlink(saved)
+        self.assertEqual(read_built_wheels(), '')
+
+
+class TestGroupHasBuilt(unittest.TestCase):
+    def _setup(self, summary_entries, wheel_index, built_csv):
+        summary_path = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False)
+        json.dump(summary_entries, summary_path)
+        summary_path.flush()
+        with open('/tmp/wheel-index.json', 'w') as f:
+            json.dump(wheel_index, f)
+        return summary_path.name
+
+    def test_has_built_wheel(self):
+        summary_path = self._setup(
+            [{'name': 'click', 'version': '8.1.0'}],
+            {'click-8.1.0': 'click-8.1.0-py3-none-any.whl'},
+            'click-8.1.0-py3-none-any.whl',
+        )
+        import io
+        from unittest.mock import patch
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
+            group_has_built(summary_path, 'click-8.1.0-py3-none-any.whl')
+            self.assertEqual(mock_out.getvalue().strip(), 'yes')
+        os.unlink(summary_path)
+
+    def test_no_built_wheel(self):
+        summary_path = self._setup(
+            [{'name': 'click', 'version': '8.1.0'}],
+            {'click-8.1.0': 'click-8.1.0-py3-none-any.whl'},
+            'other.whl',
+        )
+        import io
+        from unittest.mock import patch
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
+            group_has_built(summary_path, 'other.whl')
+            self.assertEqual(mock_out.getvalue().strip(), 'no')
+        os.unlink(summary_path)
+
+    def test_empty_summary(self):
+        summary_path = self._setup([], {}, '')
+        import io
+        from unittest.mock import patch
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_out:
+            group_has_built(summary_path, 'any.whl')
+            self.assertEqual(mock_out.getvalue().strip(), 'no')
+        os.unlink(summary_path)
+
+    def test_corrupt_json_warns(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            f.write('not json')
+            f.flush()
+        import io
+        from unittest.mock import patch
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_out, \
+             patch('sys.stderr', new_callable=io.StringIO) as mock_err:
+            group_has_built(f.name, 'any.whl')
+            self.assertEqual(mock_out.getvalue().strip(), 'no')
+            self.assertIn('WARNING', mock_err.getvalue())
+        os.unlink(f.name)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tasks/scripts/wheel-check/verify_import.py
+++ b/tasks/scripts/wheel-check/verify_import.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+"""Install a wheel via pip and verify its top-level imports succeed."""
 import importlib
 import json
 import sys
@@ -191,7 +193,10 @@ def main():
     args = [a for a in sys.argv[1:] if a != '--classify-only']
 
     if len(args) != 1:
-        print(json.dumps({"status": "ERROR", "reason": "Usage: verify_import.py [--classify-only] <wheel>"}))
+        print(json.dumps({
+            "status": "ERROR",
+            "reason": "Usage: verify_import.py [--classify-only] <wheel>",
+        }))
         sys.exit(2)
 
     wheel_path = Path(args[0])

--- a/tasks/scripts/wheel-check/verify_import.py
+++ b/tasks/scripts/wheel-check/verify_import.py
@@ -1,0 +1,254 @@
+import importlib
+import json
+import sys
+import zipfile
+from collections import defaultdict
+from pathlib import Path, PurePosixPath
+
+
+def inspect_wheel(wheel_path):
+    """Open a .whl as a zip and extract metadata for classification and import detection."""
+    with zipfile.ZipFile(wheel_path) as zf:
+        entries = zf.namelist()
+
+        dist_info_dir = None
+        for entry in entries:
+            parts = PurePosixPath(entry).parts
+            if parts and parts[0].endswith('.dist-info'):
+                dist_info_dir = parts[0]
+                break
+
+        top_level_txt = None
+        if dist_info_dir:
+            tl_path = f"{dist_info_dir}/top_level.txt"
+            if tl_path in entries:
+                top_level_txt = zf.read(tl_path).decode('utf-8', errors='replace')
+
+        content_entries = []
+        for entry in entries:
+            parts = PurePosixPath(entry).parts
+            if not parts:
+                continue
+            if parts[0].endswith(('.dist-info', '.data')):
+                continue
+            if entry.endswith('/'):
+                continue
+            content_entries.append(entry)
+
+        source_exts = {'.py', '.so', '.pyd'}
+        has_source = any(
+            PurePosixPath(e).suffix in source_exts or '.cpython-' in PurePosixPath(e).name
+            for e in content_entries
+        )
+
+    return {
+        'dist_info_dir': dist_info_dir,
+        'content_entries': content_entries,
+        'top_level_txt': top_level_txt,
+        'has_source': has_source,
+    }
+
+
+def parse_dist_info(dist_info_dir):
+    """Extract (dist_name, version) from a .dist-info directory name."""
+    base = dist_info_dir.removesuffix('.dist-info')
+    parts = base.split('-', 1)
+    if len(parts) == 2:
+        return parts[0].replace('_', '-').lower(), parts[1]
+    return base.replace('_', '-').lower(), 'unknown'
+
+
+def classify_wheel(inspection):
+    """Return 'empty', 'data-only', or 'importable' based on wheel contents."""
+    if not inspection['content_entries']:
+        return 'empty'
+    if not inspection['has_source']:
+        return 'data-only'
+    return 'importable'
+
+
+def detect_import_names(inspection):
+    """Determine importable module names from wheel zip entries.
+
+    Scans for regular packages (__init__.py), namespace packages,
+    top-level modules, and extension modules. Uses top_level.txt as
+    a supplementary hint only, validated against actual wheel contents.
+    """
+    content_entries = inspection['content_entries']
+
+    top_level_dirs = defaultdict(list)
+    top_level_files = []
+
+    for entry in content_entries:
+        parts = PurePosixPath(entry).parts
+        if not parts:
+            continue
+        if len(parts) == 1:
+            top_level_files.append(parts[0])
+        else:
+            top_level_dirs[parts[0]].append(entry)
+
+    import_names = set()
+    namespace_imports = set()
+
+    for dir_name, files in top_level_dirs.items():
+        has_init = any(
+            PurePosixPath(f).parts == (dir_name, '__init__.py')
+            for f in files
+        )
+        if has_init:
+            import_names.add(dir_name)
+
+    for dir_name, files in top_level_dirs.items():
+        if dir_name in import_names:
+            continue
+        has_py = any(
+            PurePosixPath(f).suffix in ('.py', '.so', '.pyd')
+            or '.cpython-' in PurePosixPath(f).name
+            for f in files
+        )
+        if has_py:
+            for f in files:
+                fp = PurePosixPath(f)
+                if fp.name == '__init__.py' and len(fp.parts) >= 2:
+                    dotted = '.'.join(fp.parts[:-1])
+                    namespace_imports.add(dotted)
+            if not any(ni.startswith(dir_name + '.') for ni in namespace_imports):
+                import_names.add(dir_name)
+
+    filtered_ns = set()
+    for ni in sorted(namespace_imports, key=lambda x: x.count('.')):
+        parts = ni.split('.')
+        if not any('.'.join(parts[:i]) in filtered_ns for i in range(1, len(parts))):
+            filtered_ns.add(ni)
+    namespace_imports = filtered_ns
+
+    for f in top_level_files:
+        if f.endswith('.py'):
+            import_names.add(Path(f).stem)
+
+    for f in top_level_files:
+        if f.endswith('.so') or f.endswith('.pyd') or '.cpython-' in f:
+            import_names.add(f.split('.')[0])
+
+    import_names.update(namespace_imports)
+
+    non_underscore = {
+        name for name in import_names
+        if not any(part.startswith('_') for part in name.split('.'))
+        and name != 'tests'
+        and not name.endswith('.libs')
+        and not name.startswith('pytest_')
+    }
+    if non_underscore:
+        import_names = non_underscore
+    else:
+        import_names = {
+            name for name in import_names
+            if name != 'tests'
+            and not name.endswith('.libs')
+        }
+
+    if inspection['top_level_txt']:
+        all_top_dirs = set(top_level_dirs.keys())
+        all_top_files = {Path(f).stem for f in top_level_files if f.endswith('.py')}
+        all_top_files.update(
+            f.split('.')[0] for f in top_level_files
+            if f.endswith('.so') or f.endswith('.pyd') or '.cpython-' in f
+        )
+        known_names = all_top_dirs | all_top_files
+
+        for line in inspection['top_level_txt'].splitlines():
+            tl_name = line.strip()
+            if not tl_name:
+                continue
+            if '/' in tl_name or '\\' in tl_name:
+                continue
+            if tl_name == 'tests':
+                continue
+            if tl_name.startswith('_') and import_names:
+                continue
+            if tl_name in known_names and tl_name not in import_names:
+                import_names.add(tl_name)
+
+    return import_names
+
+
+def check_import(name):
+    """Try to import a module by name; return (success, message)."""
+    try:
+        importlib.import_module(name)
+        return True, f"Successfully imported {name}"
+    except ImportError as e:
+        return False, f"ImportError: {e}"
+    except Exception as e:
+        return False, f"{type(e).__name__}: {e}"
+
+
+def main():
+    """Classify a wheel and verify its imports; output a single JSON result line."""
+    classify_only = '--classify-only' in sys.argv
+    args = [a for a in sys.argv[1:] if a != '--classify-only']
+
+    if len(args) != 1:
+        print(json.dumps({"status": "ERROR", "reason": "Usage: verify_import.py [--classify-only] <wheel>"}))
+        sys.exit(2)
+
+    wheel_path = Path(args[0])
+    if not wheel_path.exists():
+        print(json.dumps({"wheel": wheel_path.name, "status": "ERROR",
+                          "reason": f"File not found: {wheel_path}"}))
+        sys.exit(2)
+
+    inspection = inspect_wheel(wheel_path)
+
+    dist_name, version = 'unknown', 'unknown'
+    if inspection['dist_info_dir']:
+        dist_name, version = parse_dist_info(inspection['dist_info_dir'])
+
+    category = classify_wheel(inspection)
+
+    if category == 'empty':
+        print(json.dumps({"wheel": wheel_path.name, "dist_name": dist_name,
+                          "version": version, "status": "SKIP",
+                          "reason": "empty wheel (only dist-info, no source files)",
+                          "imports_tested": []}))
+        sys.exit(0)
+
+    if category == 'data-only':
+        print(json.dumps({"wheel": wheel_path.name, "dist_name": dist_name,
+                          "version": version, "status": "SKIP",
+                          "reason": "data-only package (no importable Python code)",
+                          "imports_tested": []}))
+        sys.exit(0)
+
+    if classify_only:
+        sys.exit(10)
+
+    import_names = detect_import_names(inspection)
+
+    if not import_names:
+        print(json.dumps({"wheel": wheel_path.name, "dist_name": dist_name,
+                          "version": version, "status": "FAIL",
+                          "reason": "has source files but could not determine import names",
+                          "imports_tested": []}))
+        sys.exit(1)
+
+    results = []
+    any_failed = False
+    for name in sorted(import_names):
+        success, message = check_import(name)
+        results.append({"name": name, "success": success, "message": message})
+        if not success:
+            any_failed = True
+
+    status = "FAIL" if any_failed else "PASS"
+    print(json.dumps({"wheel": wheel_path.name, "dist_name": dist_name,
+                      "version": version, "status": status,
+                      "reason": "import failures" if any_failed else "",
+                      "imports_tested": results}))
+    sys.exit(1 if any_failed else 0)
+
+
+if __name__ == '__main__':
+    main()

--- a/tasks/scripts/wheel-check/wheel_helpers.py
+++ b/tasks/scripts/wheel-check/wheel_helpers.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+"""CLI subcommands for wheel-check: result parsing, wheel index lookups, and sdist filtering."""
 import json
 import os
 import re
@@ -11,14 +12,16 @@ def normalize(name):
 
 def read_result_status(path):
     try:
-        return json.load(open(path)).get('status', 'FAIL')
+        with open(path) as f:
+            return json.load(f).get('status', 'FAIL')
     except Exception:
         return 'FAIL'
 
 
 def read_field(path, field):
     try:
-        return json.load(open(path)).get(field, '')
+        with open(path) as f:
+            return json.load(f).get(field, '')
     except Exception:
         return ''
 
@@ -39,7 +42,8 @@ def print_failed_imports(path, prefix='  '):
 
 def format_summary_row(path):
     try:
-        d = json.load(open(path))
+        with open(path) as f:
+            d = json.load(f)
         w = d.get('wheel', '?')
         s = d.get('status', 'ERROR')
         r = d.get('reason', '')
@@ -61,7 +65,8 @@ def annotate_dep(path, dep_string):
 
 
 def match_installed_wheels(wheel_index_path):
-    wheel_index = json.load(open(wheel_index_path))
+    with open(wheel_index_path) as f:
+        wheel_index = json.load(f)
     installed = json.load(sys.stdin)
     for pkg in installed:
         key = normalize(pkg['name']) + '-' + pkg['version']
@@ -71,14 +76,16 @@ def match_installed_wheels(wheel_index_path):
 
 
 def lookup_wheel(wheel_index_path, name, version):
-    wheel_index = json.load(open(wheel_index_path))
+    with open(wheel_index_path) as f:
+        wheel_index = json.load(f)
     key = normalize(name) + '-' + version
     print(wheel_index.get(key, ''))
 
 
 def extract_missing_module(path):
     try:
-        d = json.load(open(path))
+        with open(path) as f:
+            d = json.load(f)
         for t in d.get('imports_tested', []):
             if isinstance(t, dict) and not t.get('success', True):
                 msg = t.get('message', '')
@@ -95,16 +102,19 @@ def find_missing_wheel(module, tried_csv, import_map_path):
     target = normalize(module)
     tried = set(tried_csv.split(',')) if tried_csv else set()
     try:
-        import_map = json.load(open(import_map_path))
+        with open(import_map_path) as f:
+            import_map = json.load(f)
         for whl in import_map.get(target, []):
             if whl not in tried:
                 print(whl)
                 return
     except Exception:
         pass
-    for f in sorted(os.listdir('.')):
-        if f.endswith('.whl') and normalize(f.split('-')[0]) == target and f not in tried:
-            print(f)
+    for fname in sorted(os.listdir('.')):
+        if (fname.endswith('.whl')
+                and normalize(fname.split('-')[0]) == target
+                and fname not in tried):
+            print(fname)
             return
 
 
@@ -126,25 +136,29 @@ def write_skip_result(wheel_name, reason):
     }))
 
 
-def read_built_status():
+def read_built_status(path='/tmp/built-wheels.json'):
     try:
-        return json.load(open('/tmp/built-wheels.json'))['status']
+        with open(path) as f:
+            return json.load(f)['status']
     except Exception:
         return 'no_sdists'
 
 
-def read_built_wheels():
+def read_built_wheels(path='/tmp/built-wheels.json'):
     try:
-        return ','.join(json.load(open('/tmp/built-wheels.json'))['wheels'])
+        with open(path) as f:
+            return ','.join(json.load(f)['wheels'])
     except Exception:
         return ''
 
 
-def group_has_built(summary_path, built_wheels_csv):
-    built = set(built_wheels_csv.split(','))
+def group_has_built(summary_path, built_wheels_csv, wheel_index_path='/tmp/wheel-index.json'):
+    built = set(built_wheels_csv.split(',')) if built_wheels_csv else set()
     try:
-        entries = json.load(open(summary_path))
-        wheel_index = json.load(open('/tmp/wheel-index.json'))
+        with open(summary_path) as f:
+            entries = json.load(f)
+        with open(wheel_index_path) as f:
+            wheel_index = json.load(f)
         for e in entries:
             if not isinstance(e, dict):
                 continue
@@ -159,11 +173,16 @@ def group_has_built(summary_path, built_wheels_csv):
 
 
 def lookup_primary(label_raw, summary_path, wheel_index_path):
-    label = re.sub(r'[-.]', '_', label_raw).lower()
-    wheel_index = json.load(open(wheel_index_path))
-    for entry in json.load(open(summary_path)):
+    if '__' not in label_raw:
+        return
+    label_name = normalize(label_raw.split('__', 1)[0])
+    with open(wheel_index_path) as f:
+        wheel_index = json.load(f)
+    with open(summary_path) as f:
+        entries = json.load(f)
+    for entry in entries:
         norm = normalize(entry['name'])
-        if label.startswith(norm + '__'):
+        if label_name == norm:
             name = entry['name']
             version = entry['version']
             key = norm + '-' + version

--- a/tasks/scripts/wheel-check/wheel_helpers.py
+++ b/tasks/scripts/wheel-check/wheel_helpers.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+import json
+import os
+import re
+import sys
+
+
+def normalize(name):
+    return re.sub(r'[-_.]+', '_', name).lower()
+
+
+def read_result_status(path):
+    try:
+        return json.load(open(path)).get('status', 'FAIL')
+    except Exception:
+        return 'FAIL'
+
+
+def read_field(path, field):
+    try:
+        return json.load(open(path)).get(field, '')
+    except Exception:
+        return ''
+
+
+def print_failed_imports(path, prefix='  '):
+    try:
+        with open(path) as f:
+            d = json.load(f)
+        for t in d.get('imports_tested', []):
+            if not isinstance(t, dict) or t.get('success'):
+                continue
+            name = t.get('name', '<unknown>')
+            message = t.get('message', '')
+            print(f'{prefix}{name}: {message}')
+    except Exception:
+        pass
+
+
+def format_summary_row(path):
+    try:
+        d = json.load(open(path))
+        w = d.get('wheel', '?')
+        s = d.get('status', 'ERROR')
+        r = d.get('reason', '')
+        dep = d.get('undeclared_dep', '')
+        if dep:
+            r = f'undeclared dep: {dep}' if not r else f'{r} (undeclared dep: {dep})'
+    except Exception:
+        w = os.path.splitext(os.path.basename(path))[0]
+        s, r = 'FAIL', 'verify_import failed without output'
+    print(f'{s}\t{w}\t{r}')
+
+
+def annotate_dep(path, dep_string):
+    with open(path) as f:
+        d = json.load(f)
+    d['undeclared_dep'] = dep_string
+    with open(path, 'w') as f:
+        json.dump(d, f)
+
+
+def match_installed_wheels(wheel_index_path):
+    wheel_index = json.load(open(wheel_index_path))
+    installed = json.load(sys.stdin)
+    for pkg in installed:
+        key = normalize(pkg['name']) + '-' + pkg['version']
+        whl = wheel_index.get(key)
+        if whl:
+            print(whl)
+
+
+def lookup_wheel(wheel_index_path, name, version):
+    wheel_index = json.load(open(wheel_index_path))
+    key = normalize(name) + '-' + version
+    print(wheel_index.get(key, ''))
+
+
+def extract_missing_module(path):
+    try:
+        d = json.load(open(path))
+        for t in d.get('imports_tested', []):
+            if isinstance(t, dict) and not t.get('success', True):
+                msg = t.get('message', '')
+                if 'No module named' in msg:
+                    mod = msg.split("'")[1] if "'" in msg else ''
+                    if mod:
+                        print(mod.split('.')[0])
+                        return
+    except Exception:
+        pass
+
+
+def find_missing_wheel(module, tried_csv, import_map_path):
+    target = normalize(module)
+    tried = set(tried_csv.split(',')) if tried_csv else set()
+    try:
+        import_map = json.load(open(import_map_path))
+        for whl in import_map.get(target, []):
+            if whl not in tried:
+                print(whl)
+                return
+    except Exception:
+        pass
+    for f in sorted(os.listdir('.')):
+        if f.endswith('.whl') and normalize(f.split('-')[0]) == target and f not in tried:
+            print(f)
+            return
+
+
+def write_failure_result(wheel_name, reason):
+    print(json.dumps({
+        'wheel': wheel_name,
+        'status': 'FAIL',
+        'reason': reason,
+        'imports_tested': [],
+    }))
+
+
+def write_skip_result(wheel_name, reason):
+    print(json.dumps({
+        'wheel': wheel_name,
+        'status': 'SKIP',
+        'reason': reason,
+        'imports_tested': [],
+    }))
+
+
+def read_built_status():
+    try:
+        return json.load(open('/tmp/built-wheels.json'))['status']
+    except Exception:
+        return 'no_sdists'
+
+
+def read_built_wheels():
+    try:
+        return ','.join(json.load(open('/tmp/built-wheels.json'))['wheels'])
+    except Exception:
+        return ''
+
+
+def group_has_built(summary_path, built_wheels_csv):
+    built = set(built_wheels_csv.split(','))
+    try:
+        entries = json.load(open(summary_path))
+        wheel_index = json.load(open('/tmp/wheel-index.json'))
+        for e in entries:
+            if not isinstance(e, dict):
+                continue
+            key = normalize(e.get('name', '')) + '-' + str(e.get('version', ''))
+            whl = wheel_index.get(key, '')
+            if whl in built:
+                print('yes')
+                return
+    except Exception as exc:
+        print(f'WARNING: {exc}', file=sys.stderr)
+    print('no')
+
+
+def lookup_primary(label_raw, summary_path, wheel_index_path):
+    label = re.sub(r'[-.]', '_', label_raw).lower()
+    wheel_index = json.load(open(wheel_index_path))
+    for entry in json.load(open(summary_path)):
+        norm = normalize(entry['name'])
+        if label.startswith(norm + '__'):
+            name = entry['name']
+            version = entry['version']
+            key = norm + '-' + version
+            wheel = wheel_index.get(key, '')
+            print(f'{name}\n{version}\n{wheel}')
+            return
+
+
+COMMANDS = {
+    'read-status': lambda args: print(read_result_status(args[0])),
+    'read-field': lambda args: print(read_field(args[0], args[1])),
+    'print-failures': lambda args: print_failed_imports(
+        args[0],
+        prefix=args[args.index('--prefix') + 1] if '--prefix' in args else '  ',
+    ),
+    'format-row': lambda args: format_summary_row(args[0]),
+    'annotate-dep': lambda args: annotate_dep(args[0], args[1]),
+    'match-installed': lambda args: match_installed_wheels(args[0]),
+    'lookup-wheel': lambda args: lookup_wheel(args[0], args[1], args[2]),
+    'extract-missing': lambda args: extract_missing_module(args[0]),
+    'find-missing': lambda args: find_missing_wheel(args[0], args[1], args[2]),
+    'write-failure': lambda args: write_failure_result(args[0], args[1]),
+    'write-skip': lambda args: write_skip_result(args[0], args[1]),
+    'read-built-status': lambda _: print(read_built_status()),
+    'read-built-wheels': lambda _: print(read_built_wheels()),
+    'group-has-built': lambda args: group_has_built(args[0], args[1]),
+    'lookup-primary': lambda args: lookup_primary(args[0], args[1], args[2]),
+}
+
+if __name__ == '__main__':
+    cmd = sys.argv[1]
+    COMMANDS[cmd](sys.argv[2:])


### PR DESCRIPTION
…cripts

Move all inline Python from install-and-import-wheels.yaml into standalone scripts under tasks/scripts/wheel-check/, mounted via ConfigMap volume. Includes verify_import.py, wheel_helpers.py, build_wheel_index.py, build_import_map.py, and detect_built_wheels.py. The build_import_map uses inspect_wheel/detect_import_names for more accurate import-to-wheel mapping. Adds 112 unit tests covering all extracted scripts including sdist filtering (detect_built_wheels, write-skip, read-built-status, read-built-wheels, group-has-built). Zero inline Python remaining in YAML.

**NOTE:** The ConfigMap must be created in the cluster before this PR is merged:
   
  ```bash
  oc create configmap wheel-check-scripts -n calunga-tenant \
    --from-file=verify_import.py=tasks/scripts/wheel-check/verify_import.py \
    --from-file=wheel_helpers.py=tasks/scripts/wheel-check/wheel_helpers.py \
    --from-file=build_wheel_index.py=tasks/scripts/wheel-check/build_wheel_index.py \
    --from-file=build_import_map.py=tasks/scripts/wheel-check/build_import_map.py \
    --from-file=detect_built_wheels.py=tasks/scripts/wheel-check/detect_built_wheels.py
    ```
    
Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Extract wheel verification logic from the install-and-import-wheels task into reusable Python scripts mounted via a ConfigMap and make the test Python version configurable.

New Features:
- Add a PYTHON_VERSION parameter to the wheel install/import task to allow selecting the Python interpreter used for testing.

Enhancements:
- Refactor inline Python in the install-and-import-wheels task into dedicated scripts for wheel indexing, built-wheel detection, import verification, and JSON result handling.
- Improve import-to-wheel mapping by reusing wheel inspection and import name detection logic across phases of wheel testing.

Deployment:
- Mount wheel-check helper scripts from a wheel-check-scripts ConfigMap into the task container to execute extracted Python utilities.

Tests:
- Add extensive unit tests for wheel helper utilities, import verification, wheel index building, import map generation, and built-wheel detection, including sdist filtering and CLI dispatch behavior.