### PR TITLE
Switching npm sbom to spdx for parity with python

### DIFF
--- a/npm-builder/Containerfile
+++ b/npm-builder/Containerfile
@@ -2,6 +2,10 @@
 # Used by Konflux build-npm-package tasks; onboarder recipes run via build-npm-package.
 # Keep ARG BASEIMAGE in sync with baseimage.lock.
 ARG BASEIMAGE=registry.access.redhat.com/ubi8/ubi@sha256:28a85f76ad1ea0a46a81a934b02fff48d75541f77777be403d48b6bb99a363ad
+# Syft: Red Hat tech-preview image (SPDX SBOM; pin intentionally).
+ARG SYFT_IMAGE=registry.redhat.io/rh-syft-tech-preview/syft-rhel9:1.29.0-1756223792@sha256:15ed82f0b5311a570ccb8ea02135d9776c6d61e545c51b256b3fc5b5db20ba67
+
+FROM ${SYFT_IMAGE} AS syft-bin
 
 FROM ${BASEIMAGE}
 
@@ -56,6 +60,8 @@ RUN chmod +x /tmp/install-rust-toolset.sh && \
     rm -f /tmp/install-rust-toolset.sh /tmp/rust-toolset.lock && \
     dnf clean all && \
     rm -rf /var/cache/dnf
+
+COPY --from=syft-bin /usr/local/bin/syft /usr/local/bin/syft
 
 RUN useradd -m -u 1001 -s /bin/bash builder
 

--- a/npm-builder/README.md
+++ b/npm-builder/README.md
@@ -14,6 +14,7 @@ downloads from `static.rust-lang.org`.
 | Node.js 20 LTS | AppStream `nodejs:20` module | stream `20` |
 | Go | AppStream `golang` | distro default |
 | **C/C++ (node-gyp)** | **gcc-toolset-14** (CodeReady Builder) | toolset version in [`gcc-toolset.lock`](./gcc-toolset.lock); C++20 on UBI 8 glibc |
+| **SBOM** | **Syft** from `registry.redhat.io/rh-syft-tech-preview/syft-rhel9` (digest-pinned via `SYFT_IMAGE`, same as [tssc-dev-multi-ci](https://github.com/redhat-appstudio/tssc-dev-multi-ci/blob/main/Dockerfile)) | SPDX JSON → `package/sboms/redhat.spdx.json` (same name as Python wheels) |
 | **Rust** | AppStream **`rust-toolset`** module | **exact RPM VR** in [`rust-toolset.lock`](./rust-toolset.lock) |
 | node-gyp deps | `python3`, `openssl-devel`, stock `make`, etc. | stock gcc remains installed; **`CC`/`CXX`** point at toolset |
 
@@ -67,6 +68,21 @@ Built by Konflux component `npm-builder` under application `calunga-v2`:
 quay.io/redhat-user-workloads/calunga-tenant/npm-builder:<tag>
 ```
 
+### `registry.redhat.io` pull secret (required for Syft)
+
+The Containerfile `COPY --from`s Syft from `registry.redhat.io`, same pattern as
+[tssc-dev-multi-ci](https://github.com/redhat-appstudio/tssc-dev-multi-ci/blob/main/Dockerfile).
+That registry is authenticated — without a pull secret, buildah fails with
+`invalid username/password` / `Please login to the Red Hat Registry`.
+
+1. Create a [registry service account](https://access.redhat.com/terms-based-registry/accounts).
+2. In Konflux (`calunga-tenant` → Secrets), add an **Image pull secret** for
+   `registry.redhat.io` with those credentials.
+3. Link it to component **`npm-builder`** (or all components) so it attaches to
+   `build-pipeline-npm-builder`. No PipelineRun YAML change is needed.
+
+Local builds: `podman login registry.redhat.io` before `docker`/`podman` build.
+
 ## Scripts
 
 | Script | Role |
@@ -74,7 +90,7 @@ quay.io/redhat-user-workloads/calunga-tenant/npm-builder:<tag>
 | `build-npm-package` | Run entrypoint + smoke for one manifest |
 | `build-npm-packages` | Build multiple package dirs (Tekton `PACKAGES` args) |
 | `collect-npm-artifacts` | Stage `out/*.tgz` for OCI push / optional Pulp publish |
-| `generate-npm-sbom` | Embed CycloneDX into each collected `.tgz` (`package/sboms/*.cdx.json`) |
+| `generate-npm-sbom` | Syft → SPDX JSON embedded as `package/sboms/redhat.spdx.json` (Python parity) |
 | `npm-publish-pulp` | Optional Pulp npm publish (deferred; Tekton step only) |
 | `build_scripts/install-gcc-toolset.sh` | Install gcc-toolset from `gcc-toolset.lock` |
 | `build_scripts/install-rust-toolset.sh` | Install + versionlock pinned rust-toolset RPMs |
@@ -96,4 +112,5 @@ docker run --rm npm-builder g++ --version
 docker run --rm npm-builder bash -c 'echo | g++ -std=c++20 -x c++ - -o /dev/null -'
 docker run --rm npm-builder rustc --version
 docker run --rm npm-builder cargo --version
+docker run --rm npm-builder syft version
 ```

--- a/npm-builder/scripts/generate-npm-sbom
+++ b/npm-builder/scripts/generate-npm-sbom
@@ -1,16 +1,27 @@
 #!/usr/bin/env bash
-# Embed a CycloneDX 1.5 SBOM into each collected npm package tarball.
-# Mirrors Python's build-time SPDX-in-wheel: every published artifact (main and
-# platform/binary packages) gets package/sboms/<name>-<version>.cdx.json.
+# Embed an SPDX SBOM into each collected npm package tarball using Syft.
+# Parity with Python wheels: package/sboms/redhat.spdx.json (Fromager → redhat.spdx.json).
+#
+# Long-term tool: Syft (Anchore) — SPDX-JSON output, works for main + platform
+# packages, no lockfile required, common in Konflux/RHTAS pipelines.
 #
 # Usage: generate-npm-sbom [artifact-dir]
 # Default: ARTIFACT_ROOT (or ./artifact)
 set -euo pipefail
 
 ARTIFACT_DIR="${1:-${ARTIFACT_ROOT:-./artifact}}"
+SBOM_REL="sboms/redhat.spdx.json"
+
+# Avoid Syft calling out for update checks during factory builds.
+export SYFT_CHECK_FOR_APP_UPDATE="${SYFT_CHECK_FOR_APP_UPDATE:-false}"
 
 if [[ ! -d "${ARTIFACT_DIR}" ]]; then
     echo "[generate-npm-sbom] missing artifact dir: ${ARTIFACT_DIR}" >&2
+    exit 1
+fi
+
+if ! command -v syft >/dev/null 2>&1; then
+    echo "[generate-npm-sbom] ERROR: syft not found on PATH (expected in npm-builder image)" >&2
     exit 1
 fi
 
@@ -27,25 +38,6 @@ fi
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "${tmpdir}"' EXIT
 
-sbom_basename() {
-    # @calunga/foo → calunga-foo; plain name unchanged
-    local name="$1" version="$2"
-    local safe
-    safe="$(echo "${name}" | sed -e 's|^@||' -e 's|/|-|g')"
-    echo "${safe}-${version}.cdx.json"
-}
-
-npm_purl() {
-    local name="$1" version="$2"
-    if [[ "${name}" == @*/* ]]; then
-        local scope="${name%%/*}"
-        local unscoped="${name#*/}"
-        echo "pkg:npm/%40${scope#@}/${unscoped}@${version}"
-    else
-        echo "pkg:npm/${name}@${version}"
-    fi
-}
-
 embedded=0
 for tgz in "${tgz_files[@]}"; do
     [[ -f "${tgz}" ]] || continue
@@ -55,7 +47,7 @@ for tgz in "${tgz_files[@]}"; do
     extract_dir="${tmpdir}/extract-$((embedded))"
     mkdir -p "${extract_dir}"
 
-    echo "[generate-npm-sbom] embedding SBOM into ${rel}"
+    echo "[generate-npm-sbom] embedding SPDX SBOM into ${rel}"
     tar -xzf "${tgz}" -C "${extract_dir}"
 
     pkg_dir="${extract_dir}/package"
@@ -72,42 +64,21 @@ for tgz in "${tgz_files[@]}"; do
         exit 1
     fi
 
-    sbom_file="$(sbom_basename "${name}" "${version}")"
-    sbom_rel="sboms/${sbom_file}"
     mkdir -p "${pkg_dir}/sboms"
-    purl="$(npm_purl "${name}" "${version}")"
+    sbom_path="${pkg_dir}/${SBOM_REL}"
 
-    jq -n \
-        --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-        --arg name "${name}" \
-        --arg version "${version}" \
-        --arg purl "${purl}" \
-        '{
-            bomFormat: "CycloneDX",
-            specVersion: "1.5",
-            version: 1,
-            metadata: {
-                timestamp: $ts,
-                tools: [{ vendor: "calunga", name: "generate-npm-sbom", version: "0.1" }],
-                component: {
-                    type: "library",
-                    name: $name,
-                    version: $version,
-                    purl: $purl
-                }
-            },
-            components: [
-                {
-                    type: "library",
-                    name: $name,
-                    version: $version,
-                    purl: $purl
-                }
-            ]
-        }' > "${pkg_dir}/${sbom_rel}"
+    # Scan the package tree (npm metadata + files). SPDX 2.3 JSON.
+    syft scan "dir:${pkg_dir}" \
+        -o "spdx-json=${sbom_path}" \
+        --quiet
+
+    [[ -s "${sbom_path}" ]] || {
+        echo "[generate-npm-sbom] ERROR: syft did not write ${SBOM_REL} for ${rel}" >&2
+        exit 1
+    }
 
     # Ensure package.json files includes the SBOM path (npm pack / publish allowlist).
-    jq --arg sbom "${sbom_rel}" '
+    jq --arg sbom "${SBOM_REL}" '
         .files = ((.files // []) + [$sbom] | unique | sort)
     ' "${pkg_json}" > "${pkg_json}.next"
     mv "${pkg_json}.next" "${pkg_json}"
@@ -118,8 +89,8 @@ for tgz in "${tgz_files[@]}"; do
     cp -a "${pkg_dir}/." "${pack_root}/package/"
     tar --create --gzip --file "${tgz}" --directory "${pack_root}" package
 
-    echo "[generate-npm-sbom] embedded ${sbom_rel} in ${rel}"
+    echo "[generate-npm-sbom] embedded ${SBOM_REL} in ${rel} (${name}@${version})"
     embedded=$((embedded + 1))
 done
 
-echo "[generate-npm-sbom] embedded SBOM into ${embedded} tarball(s)"
+echo "[generate-npm-sbom] embedded SPDX SBOM into ${embedded} tarball(s) via syft $(syft version 2>/dev/null | head -1 || true)"

--- a/tasks/build-npm-package-oci-ta.yaml
+++ b/tasks/build-npm-package-oci-ta.yaml
@@ -10,10 +10,10 @@ metadata:
     app.kubernetes.io/version: "0.1"
 spec:
   description: >-
-    Build npm Trusted Libraries packages from onboarding recipes, generate a
-    CycloneDX SBOM, and push an OCI artifact to Quay (mirrors build-python-wheels:
-    SBOM at build; attestations at release). Optional Pulp Stage when
-    PUBLISH_TO_PULP=true.
+    Build npm Trusted Libraries packages from onboarding recipes, generate an
+    SPDX SBOM (Syft → redhat.spdx.json), and push an OCI artifact to Quay
+    (mirrors build-python-wheels: SBOM at build; attestations at release).
+    Optional Pulp Stage when PUBLISH_TO_PULP=true.
   params:
     - name: PACKAGES
       description: >-
@@ -124,7 +124,7 @@ spec:
         #!/usr/bin/env bash
         set -euo pipefail
         ARTIFACT_ROOT="${ARTIFACT_ROOT:-${WORKDIR_ROOT}/artifact}"
-        # Embed CycloneDX into every collected .tgz (main + platform), like SPDX-in-wheel.
+        # Embed SPDX (Syft → package/sboms/redhat.spdx.json) into every collected .tgz.
         generate-npm-sbom "${ARTIFACT_ROOT}"
       computeResources:
         limits:


### PR DESCRIPTION
Best practice to keep SBOM format consistent across languages unless there is a limitation.

## Summary by Sourcery

Switch npm SBOM generation to Syft-produced SPDX format and align npm artifact SBOM naming with existing Python wheels.

New Features:
- Introduce Syft-based SPDX SBOM generation for npm Trusted Libraries artifacts.

Enhancements:
- Embed a single standardized SPDX SBOM file (redhat.spdx.json) into each npm package archive for cross-language parity.
- Update the npm builder container image to include a pinned Syft binary for SBOM generation.
- Document the new SBOM tooling, image pinning, and output location in the npm-builder README.

Documentation:
- Expand npm-builder README with details on Syft usage, SBOM format, image requirements, and verification commands.