### PR TITLE
fix(builder): copy Arrow cmake config and headers into final image

### DIFF
--- a/builder/Containerfile
+++ b/builder/Containerfile
@@ -338,6 +338,8 @@ RUN find /opt/_internal -name '*.so' -printf '%h\n' | sort -u >> /etc/ld.so.conf
 # Copy build-time files (headers, pkgconfig) needed for building wheels
 COPY --from=merged_buildfs /opt /opt
 COPY --from=merged_buildfs /usr/local/lib/pkgconfig /usr/local/lib/pkgconfig
+COPY --from=merged_buildfs /usr/local/lib/cmake /usr/local/lib/cmake
+COPY --from=merged_buildfs /usr/local/include /usr/local/include
 # Create symlinks in standard paths so build systems that don't use pkg-config
 # (e.g. PyYAML's setup.py) can find our source-built headers and libraries
 RUN for dir in /opt/_internal/lib*/include /opt/_internal/openblas*/include /opt/_internal/zlib*/include /opt/_internal/bzip2*/include /opt/_internal/libomp*/include; do \


### PR DESCRIPTION
The merged_buildfs stage includes Arrow's build files but only /opt and /usr/local/lib/pkgconfig were copied into the final image, so find_package(Arrow) failed during pyarrow wheel builds.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Ensure Arrow CMake configuration files and headers from the merged build filesystem are copied into the final builder image so Arrow can be discovered during wheel builds.

Bug Fixes:
- Include /usr/local/lib/cmake and /usr/local/include from the merged build filesystem in the final builder image to fix Arrow find_package failures in pyarrow wheel builds.

Build:
- Update builder Containerfile to copy additional Arrow-related build artifacts into the final image.