### PR TITLE
Fix backfill pipeline task resolution by hardcoding release-service-catalog URL

### DIFF
--- a/pipelines/calunga-backfill-attestations.yaml
+++ b/pipelines/calunga-backfill-attestations.yaml
@@ -75,9 +75,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: $(params.taskGitUrl)
+            value: https://github.com/konflux-ci/release-service-catalog.git
           - name: revision
-            value: $(params.taskGitRevision)
+            value: production
           - name: pathInRepo
             value: tasks/managed/collect-data/collect-data.yaml
       params:
@@ -105,9 +105,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: $(params.taskGitUrl)
+            value: https://github.com/konflux-ci/release-service-catalog.git
           - name: revision
-            value: $(params.taskGitRevision)
+            value: production
           - name: pathInRepo
             value: tasks/managed/reduce-snapshot/reduce-snapshot.yaml
       params:
@@ -137,9 +137,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: $(params.taskGitUrl)
+            value: https://github.com/konflux-ci/release-service-catalog.git
           - name: revision
-            value: $(params.taskGitRevision)
+            value: production
           - name: pathInRepo
             value: tasks/managed/extract-py-artifacts/extract-py-artifacts.yaml
       params:
@@ -170,9 +170,9 @@ spec:
         resolver: "git"
         params:
           - name: url
-            value: $(params.taskGitUrl)
+            value: https://github.com/konflux-ci/release-service-catalog.git
           - name: revision
-            value: $(params.taskGitRevision)
+            value: production
           - name: pathInRepo
             value: tasks/managed/rh-sign-python-wheels/rh-sign-python-wheels.yaml
       params:


### PR DESCRIPTION
The git resolver was resolving taskRefs relative to the pipeline's own repo (calungaproject/plumbing) instead of using the $(params.taskGitUrl) default. Hardcode the release-service-catalog URL and revision directly in the 4 affected taskRefs to avoid this.

## Summary by Sourcery

Enhancements:
- Align four managed taskRefs in the backfill attestations pipeline to consistently use the release-service-catalog Git source instead of parameterized taskGitUrl/taskGitRevision.