### PR TITLE
Hardcode release-service-catalog URL part 2.

### DIFF
--- a/pipelines/calunga-backfill-attestations.yaml
+++ b/pipelines/calunga-backfill-attestations.yaml
@@ -94,9 +94,9 @@ spec:
         - name: subdirectory
           value: $(context.pipelineRun.uid)
         - name: taskGitUrl
-          value: $(params.taskGitUrl)
+          value: https://github.com/konflux-ci/release-service-catalog.git
         - name: taskGitRevision
-          value: $(params.taskGitRevision)
+          value: production
         - name: ociStorage
           value: $(tasks.config.results.ociStorage)
 
@@ -122,9 +122,9 @@ spec:
         - name: SNAPSHOT_PATH
           value: $(workspaces.data.path)/$(tasks.collect-data.results.snapshotSpec)
         - name: taskGitUrl
-          value: $(params.taskGitUrl)
+          value: https://github.com/konflux-ci/release-service-catalog.git
         - name: taskGitRevision
-          value: $(params.taskGitRevision)
+          value: production
         - name: sourceDataArtifact
           value: "$(tasks.collect-data.results.sourceDataArtifact)"
         - name: ociStorage
@@ -150,9 +150,9 @@ spec:
         - name: ociStorage
           value: $(tasks.config.results.ociStorage)
         - name: taskGitUrl
-          value: $(params.taskGitUrl)
+          value: https://github.com/konflux-ci/release-service-catalog.git
         - name: taskGitRevision
-          value: $(params.taskGitRevision)
+          value: production
         - name: dataDir
           value: /var/workdir/content
         - name: dataPath
@@ -183,9 +183,9 @@ spec:
         - name: ociStorage
           value: $(tasks.config.results.ociStorage)
         - name: taskGitUrl
-          value: $(params.taskGitUrl)
+          value: https://github.com/konflux-ci/release-service-catalog.git
         - name: taskGitRevision
-          value: $(params.taskGitRevision)
+          value: production
       runAfter:
         - extract-py-artifacts
 
@@ -219,9 +219,9 @@ spec:
         - name: dataDir
           value: /var/workdir/content
         - name: taskGitUrl
-          value: $(params.taskGitUrl)
+          value: https://github.com/konflux-ci/release-service-catalog.git
         - name: taskGitRevision
-          value: $(params.taskGitRevision)
+          value: production
         - name: ociStorage
           value: $(tasks.config.results.ociStorage)
       runAfter:


### PR DESCRIPTION
The release-service controller overrides $(params.taskGitUrl) with the pipeline's own repo URL (calungaproject/plumbing), causing tasks to fail when resolving stepactions like create-trusted-artifact. Hardcode the catalog URL in all task params to match the taskRef fix from PR #355.

## Summary by Sourcery

Bug Fixes:
- Prevent release-service pipeline tasks from failing by avoiding overrides of taskGitUrl and taskGitRevision with the controller’s repository URL.