### PR TITLE
fix(arrow): disable Boost.UUID libatomic linkage on x86_64

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
 
     steps:
     - name: Checkout code

--- a/builder/build_scripts/build-arrow.sh
+++ b/builder/build_scripts/build-arrow.sh
@@ -24,6 +24,12 @@ check_sha256sum "${ARROW_ROOT}.tar.gz" "${ARROW_HASH}"
 tar xfz "${ARROW_ROOT}.tar.gz"
 pushd "${ARROW_ROOT}/cpp"
 
+cmake_extra_args=()
+target_arch="${AUDITWHEEL_ARCH:?AUDITWHEEL_ARCH must be set}"
+if [[ "$target_arch" == "x86_64" ]]; then
+    cmake_extra_args+=( -DBOOST_UUID_LINK_LIBATOMIC=OFF )
+fi
+
 cmake -S . -B build \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
@@ -46,7 +52,8 @@ cmake -S . -B build \
     -DARROW_WITH_UTF8PROC=ON \
     -DARROW_DEPENDENCY_SOURCE=BUNDLED \
     -DCMAKE_C_FLAGS="${MANYLINUX_CFLAGS}" \
-    -DCMAKE_CXX_FLAGS="${MANYLINUX_CXXFLAGS}" > /dev/null
+    -DCMAKE_CXX_FLAGS="${MANYLINUX_CXXFLAGS}" \
+    "${cmake_extra_args[@]}" > /dev/null
 
 cmake --build build --parallel "$(nproc)" > /dev/null
 DESTDIR=/manylinux-rootfs cmake --install build > /dev/null


### PR DESCRIPTION
## Summary

- Boost.UUID 1.88 (bundled via `ARROW_DEPENDENCY_SOURCE=BUNDLED`) defaults `BOOST_UUID_LINK_LIBATOMIC=ON` for GCC, propagating `-latomic` as an `INTERFACE` dependency through all Arrow shared libraries
- On x86_64 the GCC toolset `libatomic.so` is a GNU ld linker script redirecting to `/usr/lib64/libatomic.so.1`, causing `DT_NEEDED: libatomic.so.1` in `libarrow.so`, `libarrow_compute.so`, and `libparquet.so`
- `auditwheel` whitelists `libatomic.so.1` in the `manylinux_2_28` policy and silently skips bundling it — resulting in `ImportError: libatomic.so.1` on all target platforms (UBI8/9/10, Fedora, Ubuntu)
- Fix: pass `-DBOOST_UUID_LINK_LIBATOMIC=OFF` to cmake on x86_64 (confirmed safe: zero `__atomic_*` undefined symbols in built Arrow libs)

## Test plan

- [ ] `readelf -d libarrow.so` shows no `libatomic.so.1` in `DT_NEEDED`
- [ ] All ELF files inside the repaired wheel show no `libatomic.so.1`
- [ ] `import pyarrow` succeeds on clean `ubi9/ubi:latest` without `libatomic` installed

Scripts for checking changes locally are available in the attachment. [test-libatomic-fix.zip](https://github.com/user-attachments/files/30384723/test-libatomic-fix.zip)