### PR TITLE
Adding NPM on-push tasks and scripts

### DIFF
--- a/.tekton/README.md
+++ b/.tekton/README.md
@@ -44,7 +44,18 @@ also building a new Tekton bundle for that `Task` that uses the new builder imag
 
 The `npm-builder` image is built the same way as `plumbing-builder`. The Tekton task
 `build-npm-package-oci-ta` (component `task-build-npm-package`) is consumed by the
-`npm-registry` onboarding repo.
+`npm-registry` onboarding repo (PR builds).
+
+The promote task `promote-npm-oci-ta` (component `task-promote-npm-oci`) copies a
+green `on-pr-<sha>.npm` OCI artifact to a durable `:<sha>.npm` snapshot. Verify and
+compliance logic live in npm-builder (`verify-npm-sbom`, `assess-npm-compliance`).
+Compliance queries the **public** TL npm registry (no pull secret); release upload
+still needs Pulp credentials like Python. oras pull/push stay in the task (same
+pattern as build). Bundle CI mirrors `task-build-npm-package` via
+`task-promote-npm-oci-{pull-request,push}.yaml`.
+Onboard the Konflux component + ImageRepository + SA
+`build-pipeline-task-promote-npm-oci` under `calunga-v2` before the first bundle
+build (same UI flow as `task-build-npm-package`).
 
 The `Components` use [nudges](https://konflux-ci.dev/docs/building/component-nudges/#what-is-nudged)
 to keep these dependencies up to date. If all is working as expected, Konflux should

--- a/.tekton/task-promote-npm-oci-pull-request.yaml
+++ b/.tekton/task-promote-npm-oci-pull-request.yaml
@@ -1,0 +1,41 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/calungaproject/plumbing?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && ( "tasks/promote-npm-oci-ta.yaml".pathChanged() || ".tekton/task-promote-npm-oci-pull-request.yaml".pathChanged() || ".tekton/bundle-build-pipeline.yaml".pathChanged() )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: calunga-v2
+    appstudio.openshift.io/component: task-promote-npm-oci
+    pipelines.appstudio.openshift.io/type: build
+  name: task-promote-npm-oci-on-pull-request
+  namespace: calunga-tenant
+spec:
+  params:
+    - name: git-url
+      value: '{{source_url}}'
+    - name: revision
+      value: '{{revision}}'
+    - name: output-image
+      value: quay.io/redhat-user-workloads/calunga-tenant/task-promote-npm-oci:on-pr-{{revision}}
+    - name: image-expires-after
+      value: 5d
+    - name: dockerfile
+      value: Dockerfile
+    - name: path-context
+      value: tasks/promote-npm-oci-ta.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-task-promote-npm-oci
+  workspaces:
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'
+  pipelineRef:
+    name: bundle-build
+status: {}

--- a/.tekton/task-promote-npm-oci-push.yaml
+++ b/.tekton/task-promote-npm-oci-push.yaml
@@ -1,0 +1,38 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/calungaproject/plumbing?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && ( "tasks/promote-npm-oci-ta.yaml".pathChanged() || ".tekton/task-promote-npm-oci-push.yaml".pathChanged() || ".tekton/bundle-build-pipeline.yaml".pathChanged() )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: calunga-v2
+    appstudio.openshift.io/component: task-promote-npm-oci
+    pipelines.appstudio.openshift.io/type: build
+  name: task-promote-npm-oci-on-push
+  namespace: calunga-tenant
+spec:
+  params:
+    - name: git-url
+      value: '{{source_url}}'
+    - name: revision
+      value: '{{revision}}'
+    - name: output-image
+      value: quay.io/redhat-user-workloads/calunga-tenant/task-promote-npm-oci:{{revision}}
+    - name: dockerfile
+      value: Dockerfile
+    - name: path-context
+      value: tasks/promote-npm-oci-ta.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-task-promote-npm-oci
+  workspaces:
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'
+  pipelineRef:
+    name: bundle-build
+status: {}

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ The [npm-builder](./npm-builder) directory contains the factory image for npm Tr
 Published to Quay as `npm-builder` via Konflux component `npm-builder`.
 
 Tekton task `build-npm-package-oci-ta` is bundled as `task-build-npm-package` for the
-`npm-registry` onboarding pipeline.
+`npm-registry` onboarding pipeline. Promote task `promote-npm-oci-ta` is bundled as
+`task-promote-npm-oci` (on-pr OCI → durable snapshot + compliance sidecars via public
+Pulp npm metadata query).
 
 ## Utils Image
 

--- a/npm-builder/Containerfile
+++ b/npm-builder/Containerfile
@@ -36,6 +36,7 @@ RUN dnf -y module enable nodejs:20 && \
         jq \
         which \
         findutils \
+        grep \
         patch \
         make \
         gcc \
@@ -66,7 +67,7 @@ COPY --from=syft-bin /usr/local/bin/syft /usr/local/bin/syft
 RUN useradd -m -u 1001 -s /bin/bash builder
 
 COPY --chmod=755 scripts/shasum /usr/local/bin/shasum
-COPY --chmod=755 scripts/build-npm-package scripts/build-npm-packages scripts/collect-npm-artifacts scripts/collect-npm-package-outputs scripts/generate-npm-sbom scripts/record-npm-packages-built scripts/npm-workdir-load.sh scripts/npm-publish-pulp /usr/local/bin/
+COPY --chmod=755 scripts/build-npm-package scripts/build-npm-packages scripts/collect-npm-artifacts scripts/collect-npm-package-outputs scripts/generate-npm-sbom scripts/verify-npm-sbom scripts/assess-npm-compliance scripts/lookup-npm-tl-compliance scripts/record-npm-packages-built scripts/npm-workdir-load.sh scripts/npm-publish-pulp /usr/local/bin/
 COPY --chmod=644 scripts/npm-workdir-env.sh /usr/local/lib/npm-builder/
 ENV NPM_BUILDER_LIB=/usr/local/lib/npm-builder
 

--- a/npm-builder/README.md
+++ b/npm-builder/README.md
@@ -91,6 +91,9 @@ Local builds: `podman login registry.redhat.io` before `docker`/`podman` build.
 | `build-npm-packages` | Build multiple package dirs (Tekton `PACKAGES` args) |
 | `collect-npm-artifacts` | Stage `out/*.tgz` for OCI push / optional Pulp publish |
 | `generate-npm-sbom` | Syft → SPDX JSON embedded as `package/sboms/redhat.spdx.json` (Python parity) |
+| `verify-npm-sbom` | Promote: require embedded `redhat.spdx.json` in each `.tgz` |
+| `lookup-npm-tl-compliance` | Promote helper: public registry lookup for `name@version` level |
+| `assess-npm-compliance` | Promote: inductive L1/L2/L3 via manifests + `lookup-npm-tl-compliance`; write `*.tl-compliance.json` |
 | `npm-publish-pulp` | Optional Pulp npm publish (deferred; Tekton step only) |
 | `build_scripts/install-gcc-toolset.sh` | Install gcc-toolset from `gcc-toolset.lock` |
 | `build_scripts/install-rust-toolset.sh` | Install + versionlock pinned rust-toolset RPMs |

--- a/npm-builder/scripts/assess-npm-compliance
+++ b/npm-builder/scripts/assess-npm-compliance
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+# Assess dependency-closure compliance against the public TL npm registry.
+# Writes *.tl-compliance.json sidecars next to each .tgz (outside the tarball).
+#
+# Inductive levels (no npm lockfile):
+#   L1 — one or more requires_tl_packages missing from TL
+#   L2 — all requires on TL, but at least one dep is L1 or L2
+#   L3 — no requires, OR every requires_tl_packages dep is itself L3
+#
+# Dep compliance is read from (in order): this OCI's sidecars / in-run levels,
+# then lookup-npm-tl-compliance (public registry + adjacent compliance JSON).
+#
+# Usage:
+#   assess-npm-compliance [artifact-dir] [source-root] [package-dir ...]
+# Env:
+#   ARTIFACT_ROOT, SOURCE_ROOT
+#   TL_NPM_REGISTRY_URL  (default: packages.redhat.com .../javascript)
+#
+# Requires (npm-builder image): bash, find, sort, tar, jq, python3, sha256sum,
+# awk, grep, date, basename, dirname; plus lookup-npm-tl-compliance on PATH.
+set -euo pipefail
+
+ARTIFACT_DIR="${ARTIFACT_ROOT:-./artifact}"
+SOURCE_DIR="${SOURCE_ROOT:-}"
+PACKAGE_DIRS=()
+
+if [[ $# -ge 1 ]]; then
+    ARTIFACT_DIR="$1"
+    shift
+fi
+if [[ $# -ge 1 ]]; then
+    SOURCE_DIR="$1"
+    shift
+fi
+PACKAGE_DIRS=("$@")
+
+TL_NPM_REGISTRY_URL="${TL_NPM_REGISTRY_URL:-https://packages.redhat.com/api/pulp-content/public-trusted-libraries/javascript}"
+TL_NPM_REGISTRY_URL="${TL_NPM_REGISTRY_URL%/}"
+
+for cmd in find sort tar jq python3 sha256sum awk grep date basename dirname lookup-npm-tl-compliance; do
+    if ! command -v "${cmd}" >/dev/null 2>&1; then
+        echo "[assess-npm-compliance] ERROR: required command not on PATH: ${cmd}" >&2
+        exit 1
+    fi
+done
+
+if [[ ! -d "${ARTIFACT_DIR}" ]]; then
+    echo "[assess-npm-compliance] missing artifact dir: ${ARTIFACT_DIR}" >&2
+    exit 1
+fi
+
+mapfile -t tarballs < <(find "${ARTIFACT_DIR}" -type f -name '*.tgz' | LC_ALL=C sort)
+
+if [[ ${#tarballs[@]} -eq 0 ]]; then
+    if [[ -f "${ARTIFACT_DIR}/.keep" ]]; then
+        echo "[assess-npm-compliance] no .tgz files (infra-only .keep); nothing to assess"
+        exit 0
+    fi
+    echo "[assess-npm-compliance] no .tgz files under ${ARTIFACT_DIR}" >&2
+    exit 1
+fi
+
+declare -A LOCAL_TL=()
+declare -A TGZ_FOR=() # name@version → tarball path
+for tgz in "${tarballs[@]}"; do
+    if pkg_json="$(tar -xOf "${tgz}" package/package.json 2>/dev/null)"; then
+        n="$(jq -r '.name // empty' <<<"${pkg_json}")"
+        v="$(jq -r '.version // empty' <<<"${pkg_json}")"
+        if [[ -n "${n}" && -n "${v}" ]]; then
+            LOCAL_TL["${n}@${v}"]=1
+            TGZ_FOR["${n}@${v}"]="${tgz}"
+        fi
+    fi
+done
+
+declare -a MANIFEST_PATHS=()
+if [[ ${#PACKAGE_DIRS[@]} -gt 0 ]]; then
+    if [[ -z "${SOURCE_DIR}" || ! -d "${SOURCE_DIR}" ]]; then
+        echo "[assess-npm-compliance] SOURCE_ROOT/source-root required when package dirs are given" >&2
+        exit 1
+    fi
+    for pkg in "${PACKAGE_DIRS[@]}"; do
+        m="${SOURCE_DIR}/${pkg}/manifest.json"
+        if [[ ! -f "${m}" ]]; then
+            m="${pkg}/manifest.json"
+        fi
+        if [[ ! -f "${m}" ]]; then
+            echo "[assess-npm-compliance] missing manifest: ${pkg}/manifest.json" >&2
+            exit 1
+        fi
+        MANIFEST_PATHS+=("${m}")
+    done
+elif [[ -n "${SOURCE_DIR}" && -d "${SOURCE_DIR}" ]]; then
+    while IFS= read -r m; do
+        MANIFEST_PATHS+=("${m}")
+    done < <(find "${SOURCE_DIR}/packages" -mindepth 3 -maxdepth 3 -type f -name manifest.json 2>/dev/null | LC_ALL=C sort)
+fi
+
+if [[ ${#MANIFEST_PATHS[@]} -eq 0 ]]; then
+    echo "[assess-npm-compliance] no manifests found; cannot compute requires_tl_packages" >&2
+    echo "  Provide source-root (onboarding checkout) and optional package dirs." >&2
+    exit 1
+fi
+
+declare -A OUTPUT_TO_MANIFEST=()
+declare -A MANIFEST_REQUIRES=()
+declare -A MANIFEST_SOURCE_URL=()
+declare -A MANIFEST_SOURCE_REF=()
+
+for m in "${MANIFEST_PATHS[@]}"; do
+    name="$(jq -r '.name' "${m}")"
+    version="$(jq -r '.version' "${m}")"
+    requires="$(jq -c '.requires_tl_packages // []' "${m}")"
+    src_url="$(jq -r '.source.url // empty' "${m}")"
+    src_ref="$(jq -r '.source.ref // empty' "${m}")"
+    MANIFEST_REQUIRES["${m}"]="${requires}"
+    MANIFEST_SOURCE_URL["${m}"]="${src_url}"
+    MANIFEST_SOURCE_REF["${m}"]="${src_ref}"
+
+    while IFS= read -r pulp_name; do
+        [[ -n "${pulp_name}" ]] || continue
+        OUTPUT_TO_MANIFEST["${pulp_name}@${version}"]="${m}"
+    done < <(jq -r '.outputs[].pulp_name // empty' "${m}")
+    OUTPUT_TO_MANIFEST["${name}@${version}"]="${m}"
+done
+
+# name@version → compliance level once known
+declare -A LEVELS=()
+
+# Returns 0 and prints level; exit 1 if missing from TL; exit 2 on transport error.
+lookup_dep_level() {
+    local pkg="$1"
+    local ver="$2"
+    local key="${pkg}@${ver}"
+
+    if [[ -n "${LEVELS[${key}]:-}" ]]; then
+        echo "${LEVELS[${key}]}"
+        return 0
+    fi
+
+    # Sidecar already written in this artifact dir (same promote / prior output).
+    if [[ -n "${TGZ_FOR[${key}]:-}" ]]; then
+        local tgz="${TGZ_FOR[${key}]}"
+        local base sidecar lvl
+        base="$(basename "${tgz}" .tgz)"
+        sidecar="$(dirname "${tgz}")/${base}.tl-compliance.json"
+        if [[ -f "${sidecar}" ]]; then
+            lvl="$(jq -r '.compliance_level // empty' "${sidecar}")"
+            if [[ -n "${lvl}" ]]; then
+                LEVELS["${key}"]="${lvl}"
+                echo "${lvl}"
+                return 0
+            fi
+        fi
+        # Same OCI but not assessed yet — caller should topo-order; treat as pending miss.
+        return 1
+    fi
+
+    lookup-npm-tl-compliance "${TL_NPM_REGISTRY_URL}" "${pkg}" "${ver}"
+}
+
+# Topological order of manifests: deps that appear in this OCI first.
+declare -a ORDERED_MANIFESTS=()
+declare -A MANIFEST_DONE=()
+pending=("${MANIFEST_PATHS[@]}")
+max_iters=$(( ${#pending[@]} + 2 ))
+for ((iter = 0; iter < max_iters; iter++)); do
+    [[ ${#pending[@]} -eq 0 ]] && break
+    declare -a next_pending=()
+    progress=0
+    for m in "${pending[@]}"; do
+        ready=1
+        while IFS= read -r dep; do
+            [[ -n "${dep}" ]] || continue
+            dep_name="$(jq -r '.name' <<<"${dep}")"
+            dep_ver="$(jq -r '.version' <<<"${dep}")"
+            dep_key="${dep_name}@${dep_ver}"
+            if [[ -n "${TGZ_FOR[${dep_key}]:-}" && -z "${LEVELS[${dep_key}]:-}" ]]; then
+                dep_m="${OUTPUT_TO_MANIFEST[${dep_key}]:-}"
+                if [[ -n "${dep_m}" && -z "${MANIFEST_DONE[${dep_m}]:-}" ]]; then
+                    ready=0
+                    break
+                fi
+            fi
+        done < <(jq -c '.[]' <<<"${MANIFEST_REQUIRES[${m}]}")
+        if [[ "${ready}" -eq 1 ]]; then
+            ORDERED_MANIFESTS+=("${m}")
+            MANIFEST_DONE["${m}"]=1
+            progress=1
+        else
+            next_pending+=("${m}")
+        fi
+    done
+    pending=("${next_pending[@]}")
+    [[ "${progress}" -eq 1 ]] || break
+done
+
+for m in "${MANIFEST_PATHS[@]}"; do
+    if [[ -z "${MANIFEST_DONE[${m}]:-}" ]]; then
+        ORDERED_MANIFESTS+=("${m}")
+    fi
+done
+
+assessed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+wrote=0
+
+assess_manifest() {
+    local m="$1"
+    local requires_json gaps_json gap_count level dep_levels_json
+    local dep dep_name dep_ver dep_key dep_level rc
+    local key tgz base sha256 sidecar pkg_json out_name out_version
+
+    requires_json="${MANIFEST_REQUIRES[${m}]}"
+    gaps_json='[]'
+    dep_levels_json='[]'
+
+    while IFS= read -r dep; do
+        [[ -n "${dep}" ]] || continue
+        dep_name="$(jq -r '.name' <<<"${dep}")"
+        dep_ver="$(jq -r '.version' <<<"${dep}")"
+        dep_key="${dep_name}@${dep_ver}"
+
+        set +e
+        dep_level="$(lookup_dep_level "${dep_name}" "${dep_ver}")"
+        rc=$?
+        set -e
+
+        if [[ "${rc}" -eq 2 ]]; then
+            exit 1
+        fi
+        if [[ "${rc}" -ne 0 ]]; then
+            gaps_json="$(jq -c --argjson gap "$(jq -n \
+                --arg name "${dep_name}" \
+                --arg version "${dep_ver}" \
+                '{name:$name, version:$version, reason:"not_on_tl_registry"}')" \
+                '. + [$gap]' <<<"${gaps_json}")"
+            continue
+        fi
+
+        LEVELS["${dep_key}"]="${dep_level}"
+        dep_levels_json="$(jq -c --argjson row "$(jq -n \
+            --arg name "${dep_name}" \
+            --arg version "${dep_ver}" \
+            --arg compliance_level "${dep_level}" \
+            '{name:$name, version:$version, compliance_level:$compliance_level}')" \
+            '. + [$row]' <<<"${dep_levels_json}")"
+    done < <(jq -c '.[]' <<<"${requires_json}")
+
+    gap_count="$(jq 'length' <<<"${gaps_json}")"
+    if [[ "${gap_count}" -gt 0 ]]; then
+        level="L1"
+    elif [[ "$(jq 'length' <<<"${requires_json}")" -eq 0 ]]; then
+        level="L3"
+    elif [[ "$(jq '[.[] | select(.compliance_level != "L3")] | length' <<<"${dep_levels_json}")" -eq 0 ]]; then
+        level="L3"
+    else
+        level="L2"
+    fi
+
+    for key in "${!OUTPUT_TO_MANIFEST[@]}"; do
+        [[ "${OUTPUT_TO_MANIFEST[${key}]}" == "${m}" ]] || continue
+        [[ -n "${TGZ_FOR[${key}]:-}" ]] || continue
+        tgz="${TGZ_FOR[${key}]}"
+        LEVELS["${key}"]="${level}"
+
+        pkg_json="$(tar -xOf "${tgz}" package/package.json)"
+        out_name="$(jq -r '.name' <<<"${pkg_json}")"
+        out_version="$(jq -r '.version' <<<"${pkg_json}")"
+        base="$(basename "${tgz}" .tgz)"
+        sha256="$(sha256sum "${tgz}" | awk '{print $1}')"
+        sidecar="$(dirname "${tgz}")/${base}.tl-compliance.json"
+
+        jq -n \
+            --arg name "${out_name}" \
+            --arg version "${out_version}" \
+            --arg compliance_level "${level}" \
+            --arg assessed_at "${assessed_at}" \
+            --argjson closure_gaps "${gaps_json}" \
+            --argjson requires_tl_packages "${requires_json}" \
+            --argjson dependency_levels "${dep_levels_json}" \
+            --arg src_url "${MANIFEST_SOURCE_URL[${m}]}" \
+            --arg src_ref "${MANIFEST_SOURCE_REF[${m}]}" \
+            --arg tarball "$(basename "${tgz}")" \
+            --arg tarball_sha256 "${sha256}" \
+            --arg registry "${TL_NPM_REGISTRY_URL}" \
+            '{
+              name: $name,
+              version: $version,
+              compliance_level: $compliance_level,
+              assessed_at: $assessed_at,
+              closure_gaps: $closure_gaps,
+              requires_tl_packages: $requires_tl_packages,
+              dependency_levels: $dependency_levels,
+              built_from: (if $src_url == "" then null else {url: $src_url, ref: $src_ref} end),
+              tarball: $tarball,
+              tarball_sha256: $tarball_sha256,
+              registry: $registry
+            } | with_entries(select(.value != null))' > "${sidecar}"
+
+        echo "[assess-npm-compliance] ${out_name}@${out_version} → ${level} (gaps=${gap_count}) → ${sidecar}"
+        wrote=$((wrote + 1))
+    done
+}
+
+for m in "${ORDERED_MANIFESTS[@]}"; do
+    assess_manifest "${m}"
+done
+
+echo "[assess-npm-compliance] wrote ${wrote} compliance sidecar(s) via ${TL_NPM_REGISTRY_URL}"

--- a/npm-builder/scripts/lookup-npm-tl-compliance
+++ b/npm-builder/scripts/lookup-npm-tl-compliance
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Look up TL npm registry presence and compliance level for name@version.
+
+Public registry only (no credentials). Used by assess-npm-compliance.
+
+Exit codes:
+  0 — print compliance level (L1/L2/L3) to stdout
+  1 — package/version not on TL registry
+  2 — transport / unexpected registry error
+
+Usage:
+  lookup-npm-tl-compliance <registry-base-url> <name> <version>
+"""
+from __future__ import print_function
+
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+def pkg_path(name):
+    if name.startswith("@") and "/" in name:
+        scope, pkg = name.split("/", 1)
+        return "%s%%2F%s" % (
+            urllib.parse.quote(scope, safe=""),
+            urllib.parse.quote(pkg, safe=""),
+        )
+    return urllib.parse.quote(name, safe="")
+
+
+def get_json(url):
+    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.load(resp)
+
+
+def main(argv):
+    if len(argv) != 4:
+        print(
+            "Usage: lookup-npm-tl-compliance <registry-base-url> <name> <version>",
+            file=sys.stderr,
+        )
+        return 2
+
+    registry, name, version = argv[1], argv[2], argv[3]
+    registry = registry.rstrip("/")
+    meta_url = "%s/%s" % (registry, pkg_path(name))
+
+    try:
+        data = get_json(meta_url)
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return 1
+        print(
+            "[lookup-npm-tl-compliance] registry error %s for %s" % (exc.code, meta_url),
+            file=sys.stderr,
+        )
+        return 2
+    except Exception as exc:
+        print(
+            "[lookup-npm-tl-compliance] registry request failed for %s: %s"
+            % (meta_url, exc),
+            file=sys.stderr,
+        )
+        return 2
+
+    versions = data.get("versions") or {}
+    if version not in versions:
+        return 1
+
+    # Adjacent compliance sidecar when release has published it:
+    # express@5.2.1 → .../express/-/express-5.2.1.tl-compliance.json
+    short = name.split("/")[-1]
+    comp_url = "%s/%s/-/%s-%s.tl-compliance.json" % (
+        registry,
+        pkg_path(name),
+        short,
+        version,
+    )
+    try:
+        comp = get_json(comp_url)
+        level = comp.get("compliance_level")
+        if level in ("L1", "L2", "L3"):
+            print(level)
+            return 0
+    except urllib.error.HTTPError as exc:
+        if exc.code not in (404, 301, 302):
+            print(
+                "[lookup-npm-tl-compliance] compliance fetch error %s for %s"
+                % (exc.code, comp_url),
+                file=sys.stderr,
+            )
+            return 2
+    except Exception:
+        pass
+
+    # On registry, no compliance record yet → bootstrap L3.
+    print("L3")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/npm-builder/scripts/verify-npm-sbom
+++ b/npm-builder/scripts/verify-npm-sbom
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Verify each collected .tgz embeds package/sboms/redhat.spdx.json (SPDX from Syft).
+#
+# Usage: verify-npm-sbom [artifact-dir]
+# Default: ARTIFACT_ROOT (or ./artifact)
+#
+# Requires (npm-builder image): bash, find, sort, tar, grep.
+set -euo pipefail
+
+ARTIFACT_DIR="${1:-${ARTIFACT_ROOT:-./artifact}}"
+
+for cmd in find sort tar grep; do
+    if ! command -v "${cmd}" >/dev/null 2>&1; then
+        echo "[verify-npm-sbom] ERROR: required command not on PATH: ${cmd}" >&2
+        exit 1
+    fi
+done
+
+if [[ ! -d "${ARTIFACT_DIR}" ]]; then
+    echo "[verify-npm-sbom] missing artifact dir: ${ARTIFACT_DIR}" >&2
+    exit 1
+fi
+
+mapfile -t tarballs < <(find "${ARTIFACT_DIR}" -type f -name '*.tgz' | LC_ALL=C sort)
+
+if [[ ${#tarballs[@]} -eq 0 ]]; then
+    if [[ -f "${ARTIFACT_DIR}/.keep" ]]; then
+        echo "[verify-npm-sbom] no .tgz files (infra-only .keep); ok"
+        exit 0
+    fi
+    echo "[verify-npm-sbom] no .tgz files under ${ARTIFACT_DIR}" >&2
+    exit 1
+fi
+
+for tgz in "${tarballs[@]}"; do
+    echo "[verify-npm-sbom] checking ${tgz}"
+    if ! tar -tzf "${tgz}" | grep -qE '(^|/)package/sboms/redhat\.spdx\.json$'; then
+        echo "[verify-npm-sbom] missing package/sboms/redhat.spdx.json in ${tgz}" >&2
+        exit 1
+    fi
+done
+
+echo "[verify-npm-sbom] verified SPDX SBOM in ${#tarballs[@]} tarball(s)"

--- a/tasks/promote-npm-oci-ta.yaml
+++ b/tasks/promote-npm-oci-ta.yaml
@@ -1,0 +1,237 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: promote-npm-oci-ta
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: npm, konflux, trusted-libraries
+  labels:
+    app.kubernetes.io/version: "0.1"
+spec:
+  description: >-
+    Promote a PR npm OCI artifact (on-pr-<sha>.npm) to a durable snapshot tag
+    (<sha>.npm): oras pull → verify embedded SPDX SBOM → assess compliance
+    against the public TL npm registry (*.tl-compliance.json) → oras push.
+    No rebuild. Verify/compliance scripts live in the npm-builder image.
+  params:
+    - name: SOURCE_IMAGE
+      description: >-
+        Quay OCI reference for the PR artifact to promote
+        (e.g. …/calunga-npm-registry-main:on-pr-<sha>.npm)
+      type: string
+    - name: IMAGE
+      description: >-
+        Durable Quay OCI reference to push
+        (e.g. …/calunga-npm-registry-main:<sha>.npm)
+      type: string
+    - name: BUILDER_IMAGE
+      description: Pinned npm-builder image (hosts verify-npm-sbom / assess-npm-compliance)
+      type: string
+    - name: SOURCE_ARTIFACT
+      description: Trusted Artifact URI with the onboarding repo checkout (manifests)
+      type: string
+    - name: PACKAGES
+      description: >-
+        Package directories whose manifests supply requires_tl_packages
+        (e.g. ["packages/express/5.2.1"])
+      type: array
+    - name: TL_NPM_REGISTRY_URL
+      description: Public TL npm registry base URL (read-only; no credentials)
+      type: string
+      default: https://packages.redhat.com/api/pulp-content/public-trusted-libraries/javascript
+    - name: IMAGE_EXPIRES_AFTER
+      description: >-
+        Delete image tag after specified time. Empty means keep the tag.
+        Durable snapshots should leave this empty.
+      type: string
+      default: ""
+    - name: WORKDIR_ROOT
+      description: Writable emptyDir mount for pull / stage / push
+      type: string
+      default: /var/workdir
+    - name: caTrustConfigMapKey
+      type: string
+      default: ca-bundle.crt
+    - name: caTrustConfigMapName
+      type: string
+      default: trusted-ca
+  results:
+    - name: IMAGE_DIGEST
+      description: Digest of the durable OCI artifact just pushed
+    - name: IMAGE_URL
+      description: OCI artifact repository and tag
+    - name: IMAGE_REF
+      description: OCI artifact reference (image@digest)
+    - name: SOURCE_IMAGE
+      description: Source (on-pr) OCI reference that was promoted
+  volumes:
+    - name: trusted-ca
+      configMap:
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        name: $(params.caTrustConfigMapName)
+        optional: true
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    env:
+      - name: WORKDIR_ROOT
+        value: $(params.WORKDIR_ROOT)
+      - name: ARTIFACT_ROOT
+        value: $(params.WORKDIR_ROOT)/artifact
+      - name: SOURCE_ROOT
+        value: $(params.WORKDIR_ROOT)/source
+    volumeMounts:
+      - mountPath: $(params.WORKDIR_ROOT)
+        name: workdir
+  steps:
+    - name: use-trusted-artifact
+      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:2712c8a6453fc9db5fc4c2d9d952554a4eea46d2fdba47a272b79fa07f8c8c40
+      args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=$(params.WORKDIR_ROOT)/source
+      volumeMounts:
+        - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+          name: trusted-ca
+          readOnly: true
+          subPath: ca-bundle.crt
+
+    - name: pull-on-pr-artifact
+      image: quay.io/konflux-ci/oras:latest@sha256:1beeecce012c99794568f74265c065839f9703d28306a8430b667f639343a98b
+      workingDir: $(params.WORKDIR_ROOT)
+      volumeMounts:
+        - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+          name: trusted-ca
+          readOnly: true
+          subPath: ca-bundle.crt
+      env:
+        - name: SOURCE_IMAGE
+          value: $(params.SOURCE_IMAGE)
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        echo "[$(date --utc -Ins)] Pulling on-pr npm OCI artifact: ${SOURCE_IMAGE}"
+
+        select-oci-auth "${SOURCE_IMAGE}" > auth.json
+        AUTHFILE="$(realpath auth.json)"
+
+        mkdir -p "${ARTIFACT_ROOT}"
+        if ! retry oras pull --registry-config "${AUTHFILE}" "${SOURCE_IMAGE}" -o "${ARTIFACT_ROOT}"
+        then
+          echo "Failed to pull ${SOURCE_IMAGE}" >&2
+          echo "Promote requires a green on-pr build for this SHA at the SOURCE_IMAGE tag." >&2
+          exit 1
+        fi
+
+        echo -n "${SOURCE_IMAGE}" | tee "$(results.SOURCE_IMAGE.path)"
+        ls -la "${ARTIFACT_ROOT}"
+        echo "[$(date --utc -Ins)] End pull-on-pr-artifact"
+      computeResources:
+        limits:
+          memory: 1Gi
+        requests:
+          cpu: "500m"
+          memory: 512Mi
+
+    - name: verify-sbom
+      image: $(params.BUILDER_IMAGE)
+      command:
+        - verify-npm-sbom
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          cpu: "100m"
+          memory: 128Mi
+
+    - name: assess-compliance
+      image: $(params.BUILDER_IMAGE)
+      env:
+        - name: TL_NPM_REGISTRY_URL
+          value: $(params.TL_NPM_REGISTRY_URL)
+      # Pass PACKAGES as discrete argv entries (avoids bash word-splitting/globbing).
+      # Network required: public Pulp npm metadata (no credentials).
+      command:
+        - assess-npm-compliance
+      args:
+        - $(params.WORKDIR_ROOT)/artifact
+        - $(params.WORKDIR_ROOT)/source
+        - $(params.PACKAGES[*])
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          cpu: "100m"
+          memory: 256Mi
+
+    - name: create-oci-artifact
+      image: quay.io/konflux-ci/oras:latest@sha256:1beeecce012c99794568f74265c065839f9703d28306a8430b667f639343a98b
+      workingDir: $(params.WORKDIR_ROOT)
+      volumeMounts:
+        - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+          name: trusted-ca
+          readOnly: true
+          subPath: ca-bundle.crt
+      env:
+        - name: IMAGE
+          value: $(params.IMAGE)
+        - name: IMAGE_EXPIRES_AFTER
+          value: $(params.IMAGE_EXPIRES_AFTER)
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        echo "[$(date --utc -Ins)] Pushing durable npm OCI snapshot: ${IMAGE}"
+
+        select-oci-auth "$IMAGE" > auth.json
+        AUTHFILE="$(realpath auth.json)"
+
+        EXPIRE_LABEL=()
+        [ -n "$IMAGE_EXPIRES_AFTER" ] && EXPIRE_LABEL=("--annotation" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
+
+        PUSH_DIR="$(mktemp -d)"
+        if [[ -d "${ARTIFACT_ROOT}" ]]; then
+          cp -a "${ARTIFACT_ROOT}/." "${PUSH_DIR}/" 2>/dev/null || true
+        fi
+        cd "${PUSH_DIR}"
+
+        shopt -s nullglob dotglob
+        artifact_files=(*)
+        if [[ ${#artifact_files[@]} -eq 0 ]]; then
+          echo "No artifacts to push after promote staging" >&2
+          exit 1
+        fi
+        shopt -u dotglob
+
+        echo "Pushing OCI artifact to ${IMAGE}"
+        if ! retry oras push "$IMAGE" \
+          --registry-config "${AUTHFILE}" \
+          "${EXPIRE_LABEL[@]}" \
+          --artifact-type "application/vnd.npm.packages" \
+          "${artifact_files[@]}"
+        then
+          echo "Failed to push OCI artifact ${IMAGE} to registry" >&2
+          exit 1
+        fi
+
+        if ! RESULTING_DIGEST=$(retry oras resolve \
+          --registry-config "${AUTHFILE}" "${IMAGE}")
+        then
+          echo "Failed to get digest for ${IMAGE} from registry" >&2
+          exit 1
+        fi
+
+        echo -n "$IMAGE" | tee "$(results.IMAGE_URL.path)"
+        echo -n "$RESULTING_DIGEST" | tee "$(results.IMAGE_DIGEST.path)"
+        echo -n "${IMAGE}@${RESULTING_DIGEST}" | tee "$(results.IMAGE_REF.path)"
+
+        echo "[$(date --utc -Ins)] End create-oci-artifact"
+      computeResources:
+        limits:
+          memory: 1Gi
+        requests:
+          cpu: "1"
+          memory: 1Gi


### PR DESCRIPTION
Adds tasks and script that will handle npm-registry on-push pipeline.

Assisted by Cursor 3.5.53

## Summary by Sourcery

Introduce an npm OCI promotion task and wire it into Konflux bundle build pipelines with compliance verification support.

New Features:
- Add a Tekton task to promote PR npm OCI artifacts to durable snapshot tags with SBOM verification and compliance assessment.
- Add pull-request and push bundle-build PipelineRuns for the npm OCI promotion task in the Konflux tenant.

Enhancements:
- Extend the npm-builder image with additional verification and compliance helper scripts and required tooling.
- Document the npm promotion task, its compliance behavior, and how it integrates with the npm-registry onboarding pipeline and Konflux components.

Build:
- Include the npm OCI promotion task in the bundle-build path via new on-pull-request and on-push PipelineRun definitions.