### PR TITLE
Add npm promote task to EC trusted task list

### DIFF
--- a/policy-data/trusted_task_rules.yaml
+++ b/policy-data/trusted_task_rules.yaml
@@ -1,12 +1,16 @@
 ---
-# CTRL-004: Register build-python-wheels-oci-ta as a trusted task in Enterprise Contract.
+# Register Calunga factory/promote Tekton task bundles as trusted in Enterprise Contract.
 #
 # This file is referenced as a data source in Calunga's EC policies so that
 # Conforma can verify the build task without maintaining a separate
 # data-acceptable-bundles OCI artifact.  See ADR 0053 for background:
 # https://konflux-ci.dev/architecture/ADR/0053-trusted-task-model/
+#
+# Consumed by ECP e.g. calunga-npm / index policies via:
+#   github.com/calungaproject/plumbing//policy-data?ref=main
 trusted_task_rules:
   allow:
     calunga-build-tasks:
       - pattern: oci://quay.io/redhat-user-workloads/calunga-tenant/task-build-python-wheels*
       - pattern: oci://quay.io/redhat-user-workloads/calunga-tenant/task-build-npm-package*
+      - pattern: oci://quay.io/redhat-user-workloads/calunga-tenant/task-promote-npm-oci*


### PR DESCRIPTION
## Summary by Sourcery

Register additional Calunga Tekton task bundles as trusted in Enterprise Contract policies.

Enhancements:
- Add npm promote Tekton task bundle to the Enterprise Contract trusted task allowlist for Calunga build tasks.
- Clarify and expand documentation comments on how Calunga EC policies consume the trusted task rules data source.