### PR TITLE
Fix EC warnings

### DIFF
--- a/policy-data/pipeline-required-tasks.yaml
+++ b/policy-data/pipeline-required-tasks.yaml
@@ -1,0 +1,27 @@
+---
+# Required Tekton tasks for Calunga npm factory / promote pipelines.
+#
+# Keys must match the selector Conforma reads from the attestation:
+#   1. build.appstudio.redhat.com/build_type on the build Task, or
+#   2. pipelines.openshift.io/runtime on the PipelineRun / Pipeline
+#
+# Task names are Task metadata.name values (not Pipeline task names).
+# Consumed via ECP data source:
+#   github.com/calungaproject/plumbing//policy-data?ref=main
+#
+# See: https://conforma.dev/docs/policy/packages/release_tasks.html
+pipeline-required-tasks:
+  build-npm:
+    - effective_on: "2026-01-01T00:00:00Z"
+      tasks:
+        - init
+        - git-clone-oci-ta
+        - run-script-oci-ta
+        - build-npm-package-oci-ta
+  promote-npm:
+    - effective_on: "2026-01-01T00:00:00Z"
+      tasks:
+        - init
+        - git-clone-oci-ta
+        - run-script-oci-ta
+        - promote-npm-oci-ta

--- a/tasks/build-npm-package-oci-ta.yaml
+++ b/tasks/build-npm-package-oci-ta.yaml
@@ -8,6 +8,9 @@ metadata:
     tekton.dev/tags: npm, konflux, trusted-libraries
   labels:
     app.kubernetes.io/version: "0.1"
+    # Conforma pipeline-required-tasks selector (see policy-data/).
+    build.appstudio.redhat.com/build_type: build-npm
+
 spec:
   description: >-
     Build npm Trusted Libraries packages from onboarding recipes, generate an

--- a/tasks/promote-npm-oci-ta.yaml
+++ b/tasks/promote-npm-oci-ta.yaml
@@ -8,6 +8,9 @@ metadata:
     tekton.dev/tags: npm, konflux, trusted-libraries
   labels:
     app.kubernetes.io/version: "0.1"
+    # Conforma pipeline-required-tasks selector (see policy-data/).
+    build.appstudio.redhat.com/build_type: promote-npm
+
 spec:
   description: >-
     Promote a PR npm OCI artifact (on-pr-<sha>.npm) to a durable snapshot tag


### PR DESCRIPTION
## Summary by Sourcery

Align npm build and promote Tekton tasks with Conforma’s pipeline-required-tasks policy data for Calunga npm pipelines.

Enhancements:
- Tag npm build and promote Tekton tasks with build_type labels used by Conforma for policy enforcement.
- Introduce centralized policy-data defining required Tekton tasks for Calunga npm build and promote pipelines.