### PR TITLE
Adding oras and npm extract script to utils image

### DIFF
--- a/utils/Containerfile
+++ b/utils/Containerfile
@@ -4,6 +4,10 @@
 # Cosign from Red Hat Trusted Artifact Signer.
 FROM registry.redhat.io/rhtas/cosign-rhel9:1.3.6@sha256:ff6a2a11b8c1dff47cb115cfa3ba5709bff5f1cf485bdaecff47f1a37cad2405 AS cosign
 
+# ORAS client from Konflux's UBI-based image (no registry.redhat.io/oras equivalent;
+# same source release-service-utils uses).
+FROM quay.io/konflux-ci/oras:latest@sha256:6cea0b9e142c2e18429f5cd30d716715d932047cbf1631334c5c31f7e47c3a19 AS oras
+
 FROM registry.access.redhat.com/ubi10/ubi:latest as ubi
 
 ########################
@@ -37,6 +41,8 @@ LABEL maintainer="Red Hat"
 
 COPY --from=builder /venv /venv
 COPY --from=cosign /usr/local/bin/cosign /usr/local/bin/cosign
+COPY --from=oras /usr/bin/oras /usr/local/bin/oras
+COPY --from=oras /usr/local/bin/retry /usr/local/bin/retry
 
 COPY scripts/* /usr/local/bin/
 

--- a/utils/scripts/npm-extract-artifacts
+++ b/utils/scripts/npm-extract-artifacts
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Pull npm package artifacts from digest-pinned snapshot images with oras.
+#
+# Env:
+#   FILES_DIR      Output root for digest-namespaced extract dirs (required)
+#   IMAGES_TXT     File listing digest-pinned image refs (required)
+#   ORAS_OPTIONS   Extra oras flags (optional, shell-split)
+#
+set -euo pipefail
+
+FILES_DIR="${FILES_DIR:?FILES_DIR required}"
+IMAGES_TXT="${IMAGES_TXT:?IMAGES_TXT required}"
+
+AUTHFILE='/tmp/auth.json'
+mkdir -p "${FILES_DIR}"
+
+while read -r IMAGE; do
+  [[ -n "${IMAGE}" ]] || continue
+  echo "Processing ${IMAGE}"
+  # Require digest-pinned refs; sanitize for path use (colon/slash unsafe).
+  DIGEST="${IMAGE##*@}"
+  if [[ ! "${DIGEST}" =~ ^sha256:[a-fA-F0-9]{64}$ ]]; then
+    echo "ERROR: image must be digest-pinned (got ${IMAGE})" >&2
+    exit 1
+  fi
+  DIGEST_SAFE="${DIGEST//[:\/]/_}"
+  OUT_DIR="${FILES_DIR}/${DIGEST_SAFE}"
+  mkdir -p "${OUT_DIR}"
+  select-oci-auth "${IMAGE}" > "${AUTHFILE}"
+  # ORAS_OPTIONS is intentionally unquoted so callers can pass multiple flags
+  # (e.g. "--insecure --registry-config ...").
+  # shellcheck disable=SC2086
+  retry oras pull ${ORAS_OPTIONS:-} --registry-config "${AUTHFILE}" \
+    "${IMAGE}" -o "${OUT_DIR}"
+done < "${IMAGES_TXT}"
+
+# Top-level only — recursive listing balloons Tekton logs on large trees.
+echo "Extracted top-level entries under ${FILES_DIR}:"
+ls -la "${FILES_DIR}"


### PR DESCRIPTION
Since oras image does not have python need to add oras to our utils image to be able to wrap it with python inline in the release-service-catalog repo PR. This is a new requirement from RSC.

## Summary by Sourcery

Add ORAS client and npm artifact extraction support to the utils container image.

New Features:
- Include the ORAS CLI and retry helper in the utils container image for use by release-service tooling.
- Add an npm-extract-artifacts script to support extracting artifacts from npm packages in automation workflows.

Build:
- Extend the utils Containerfile to pull ORAS from the Konflux UBI-based image and copy its binaries into the final image.