### PR TITLE
Create driver scripts for single command tasks on RSC

### DIFF
--- a/npm-builder/scripts/assess-npm-compliance
+++ b/npm-builder/scripts/assess-npm-compliance
@@ -52,10 +52,6 @@ fi
 mapfile -t tarballs < <(find "${ARTIFACT_DIR}" -type f -name '*.tgz' | LC_ALL=C sort)
 
 if [[ ${#tarballs[@]} -eq 0 ]]; then
-    if [[ -f "${ARTIFACT_DIR}/.keep" ]]; then
-        echo "[assess-npm-compliance] no .tgz files (infra-only .keep); nothing to assess"
-        exit 0
-    fi
     echo "[assess-npm-compliance] no .tgz files under ${ARTIFACT_DIR}" >&2
     exit 1
 fi

--- a/npm-builder/scripts/build-npm-packages
+++ b/npm-builder/scripts/build-npm-packages
@@ -6,11 +6,11 @@ set -euo pipefail
 
 usage() {
     cat <<'EOF'
-Usage: build-npm-packages [<pkg-dir> ...]
+Usage: build-npm-packages <pkg-dir> [<pkg-dir> ...]
 
-Build onboarder recipes via build-npm-package. With no package dirs, prepares an
-empty artifact for infra-only pipeline runs. Writes package dirs, one per line,
-to BUILT_LIST (under WORKDIR_ROOT, default /var/workdir/built/list.txt).
+Build onboarder recipes via build-npm-package. At least one package directory is
+required. Writes package dirs, one per line, to BUILT_LIST (under WORKDIR_ROOT,
+default /var/workdir/built/list.txt).
 
 Environment:
   WORKDIR_ROOT   Factory scratch root (Tekton: /var/workdir)
@@ -27,8 +27,9 @@ mkdir -p "$(dirname "${BUILT_LIST}")" "${WORK_ROOT}" "${OUTPUT_ROOT}"
 : > "${BUILT_LIST}"
 
 if [[ $# -lt 1 ]]; then
-    echo "[build-npm-packages] no packages to build (infra-only)"
-    exit 0
+    echo "[build-npm-packages] ERROR: no packages to build" >&2
+    usage >&2
+    exit 1
 fi
 
 for pkg in "$@"; do

--- a/npm-builder/scripts/collect-npm-package-outputs
+++ b/npm-builder/scripts/collect-npm-package-outputs
@@ -14,9 +14,8 @@ if [[ ! -f "${BUILT_LIST}" ]]; then
 fi
 
 if [[ ! -s "${BUILT_LIST}" ]]; then
-    touch "${ARTIFACT_ROOT}/.keep"
-    echo "[collect-npm-package-outputs] empty artifact (.keep only)"
-    exit 0
+    echo "[collect-npm-package-outputs] ERROR: built list is empty (no packages built)" >&2
+    exit 1
 fi
 
 while IFS= read -r pkg; do

--- a/npm-builder/scripts/verify-npm-sbom
+++ b/npm-builder/scripts/verify-npm-sbom
@@ -24,10 +24,6 @@ fi
 mapfile -t tarballs < <(find "${ARTIFACT_DIR}" -type f -name '*.tgz' | LC_ALL=C sort)
 
 if [[ ${#tarballs[@]} -eq 0 ]]; then
-    if [[ -f "${ARTIFACT_DIR}/.keep" ]]; then
-        echo "[verify-npm-sbom] no .tgz files (infra-only .keep); ok"
-        exit 0
-    fi
     echo "[verify-npm-sbom] no .tgz files under ${ARTIFACT_DIR}" >&2
     exit 1
 fi

--- a/tasks/build-npm-package-oci-ta.yaml
+++ b/tasks/build-npm-package-oci-ta.yaml
@@ -173,9 +173,15 @@ spec:
         shopt -s nullglob dotglob
         artifact_files=(*)
         if [[ ${#artifact_files[@]} -eq 0 ]]; then
-          echo "No npm artifacts to push; using placeholder .keep (infra-only run)"
-          touch .keep
-          artifact_files=(.keep)
+          echo "No npm artifacts to push under ${PUSH_DIR}" >&2
+          exit 1
+        fi
+        # Require at least one package tarball (no .keep placeholders).
+        mapfile -t tgz_found < <(find . -type f -name '*.tgz' | head -n 1)
+        if [[ ${#tgz_found[@]} -eq 0 ]]; then
+          echo "No .tgz packages to push (refusing empty / placeholder OCI)" >&2
+          ls -la >&2 || true
+          exit 1
         fi
         shopt -u dotglob
 

--- a/tasks/promote-npm-oci-ta.yaml
+++ b/tasks/promote-npm-oci-ta.yaml
@@ -16,8 +16,8 @@ spec:
     Promote a PR npm OCI artifact (on-pr-<sha>.npm) to a durable snapshot tag
     (<sha>.npm): oras pull → verify embedded SPDX SBOM → assess compliance
     against the public TL npm registry (*.tl-compliance.json) → oras push.
-    No rebuild. When PACKAGES_STATUS is no-packages, skips pull and publishes
-    an empty (.keep) durable artifact so infra-only merges stay green.
+    No rebuild. Requires PACKAGES_STATUS=has-packages and at least one .tgz
+    in the on-pr artifact (PAC should only start promote when packages/ change).
   params:
     - name: SOURCE_IMAGE
       description: >-
@@ -42,8 +42,8 @@ spec:
       type: array
     - name: PACKAGES_STATUS
       description: >-
-        From identify-packages SCRIPT_OUTPUT: has-packages or no-packages.
-        no-packages skips on-pr pull and pushes a .keep durable tag.
+        From identify-packages SCRIPT_OUTPUT: must be has-packages. no-packages
+        fails the task (infra-only merges are skipped by PAC path filters).
       type: string
       default: has-packages
     - name: TL_NPM_REGISTRY_URL
@@ -74,7 +74,7 @@ spec:
     - name: IMAGE_REF
       description: OCI artifact reference (image@digest)
     - name: SOURCE_IMAGE
-      description: Source (on-pr) OCI reference that was promoted (or skipped)
+      description: Source (on-pr) OCI reference that was promoted
   volumes:
     - name: trusted-ca
       configMap:
@@ -127,12 +127,10 @@ spec:
 
         mkdir -p "${ARTIFACT_ROOT}"
 
-        if [[ "${PACKAGES_STATUS}" == "no-packages" ]]; then
-          echo "[$(date --utc -Ins)] No packages in this merge; skipping on-pr pull"
-          touch "${ARTIFACT_ROOT}/.keep"
-          echo -n "skipped:no-packages" | tee "$(results.SOURCE_IMAGE.path)"
-          echo "[$(date --utc -Ins)] End pull-on-pr-artifact (skipped)"
-          exit 0
+        if [[ "${PACKAGES_STATUS}" != "has-packages" ]]; then
+          echo "ERROR: PACKAGES_STATUS=${PACKAGES_STATUS}; expected has-packages" >&2
+          echo "Infra-only merges should be skipped by PAC packages/ path filters." >&2
+          exit 1
         fi
 
         echo "[$(date --utc -Ins)] Pulling on-pr npm OCI artifact: ${SOURCE_IMAGE}"
@@ -147,6 +145,12 @@ spec:
           echo "Note: GitHub merge/squash SHAs usually differ from the PR head SHA used" >&2
           echo "for on-pr-<sha>.npm — the push revision must match the PR build revision," >&2
           echo "or promote must resolve the PR artifact another way." >&2
+          exit 1
+        fi
+
+        if ! find "${ARTIFACT_ROOT}" -type f -name '*.tgz' | grep -q .; then
+          echo "ERROR: pulled ${SOURCE_IMAGE} but found no .tgz under ${ARTIFACT_ROOT}" >&2
+          ls -la "${ARTIFACT_ROOT}" >&2 || true
           exit 1
         fi
 
@@ -165,10 +169,6 @@ spec:
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
-        if [[ "${PACKAGES_STATUS}" == "no-packages" ]]; then
-          echo "[verify-sbom] skipped (no-packages)"
-          exit 0
-        fi
         verify-npm-sbom
       computeResources:
         limits:
@@ -187,10 +187,6 @@ spec:
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
-        if [[ "${PACKAGES_STATUS}" == "no-packages" ]]; then
-          echo "[assess-compliance] skipped (no-packages)"
-          exit 0
-        fi
         assess-npm-compliance \
           "$(params.WORKDIR_ROOT)/artifact" \
           "$(params.WORKDIR_ROOT)/source" \
@@ -239,6 +235,12 @@ spec:
         artifact_files=(*)
         if [[ ${#artifact_files[@]} -eq 0 ]]; then
           echo "No artifacts to push after promote staging" >&2
+          exit 1
+        fi
+        mapfile -t tgz_found < <(find . -type f -name '*.tgz' | head -n 1)
+        if [[ ${#tgz_found[@]} -eq 0 ]]; then
+          echo "No .tgz packages to push (refusing empty / placeholder OCI)" >&2
+          ls -la >&2 || true
           exit 1
         fi
         shopt -u dotglob

--- a/utils/Containerfile
+++ b/utils/Containerfile
@@ -34,17 +34,32 @@ RUN python3 -m venv /venv && \
     /venv/bin/pip install -r requirements.txt --no-deps --no-cache-dir --require-hashes
 
 ##########################
+# UNIT TESTS (must pass)
+##########################
+FROM base AS test
+COPY scripts /src/scripts
+COPY tests /src/tests
+RUN chmod +x /src/scripts/* /src/tests/run_tests.sh \
+    && /src/tests/run_tests.sh \
+    && touch /tmp/utils-tests-ok
+
+##########################
 # ASSEMBLE THE FINAL IMAGE
 ##########################
 FROM base
 LABEL maintainer="Red Hat"
+
+# Gate the final image on the unit-test stage.
+COPY --from=test /tmp/utils-tests-ok /tmp/utils-tests-ok
 
 COPY --from=builder /venv /venv
 COPY --from=cosign /usr/local/bin/cosign /usr/local/bin/cosign
 COPY --from=oras /usr/bin/oras /usr/local/bin/oras
 COPY --from=oras /usr/local/bin/retry /usr/local/bin/retry
 
-COPY scripts/* /usr/local/bin/
+# --chmod applies only to these copied scripts (not cosign/oras/retry already
+# present in /usr/local/bin).
+COPY --chmod=755 scripts/* /usr/local/bin/
 
 RUN ln -s /venv/bin/twine /usr/local/bin/twine
 

--- a/utils/scripts/npm-common.sh
+++ b/utils/scripts/npm-common.sh
@@ -2,6 +2,25 @@
 # Shared helpers for npm pulp release scripts. Source from other scripts:
 #   # shellcheck source=npm-common.sh
 #   source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/npm-common.sh"
+# Prefer sibling when running from a checkout; fall back to PATH install:
+#   source "$(command -v npm-common.sh)"
+
+# Write ERROR status for Tekton results.status (do not write Success — that
+# belongs to record-success after create-trusted-artifact).
+write_status_error() {
+  local detail="${1:-unknown error}"
+  if [[ -n "${STATUS_PATH:-}" ]]; then
+    printf 'ERROR: %s\n' "${detail}" > "${STATUS_PATH}"
+  fi
+}
+
+# Fail with stderr + optional STATUS_PATH update.
+fail_with_status() {
+  local detail="${1:-unknown error}"
+  echo "ERROR: ${detail}" >&2
+  write_status_error "${detail}"
+  exit 1
+}
 
 # Fail if the named tar member is missing, empty, or larger than max_bytes.
 # Probes with head -c so we never buffer more than max+1 bytes.

--- a/utils/scripts/npm-populate-release-notes
+++ b/utils/scripts/npm-populate-release-notes
@@ -184,10 +184,10 @@ rm -f "${ARTIFACTS_JSONL}"
 
 ARTIFACT_COUNT="$(jq 'length' <<<"${DEDUPED}")"
 if [[ "${ARTIFACT_COUNT}" -eq 0 ]]; then
-  echo "WARNING: No .tgz files found (infra-only / empty snapshot); continuing"
-else
-  echo "Adding ${ARTIFACT_COUNT} artifact(s) to releaseNotes.content.artifacts"
+  echo "ERROR: No .tgz files found under ${FILES_DIR}" >&2
+  exit 1
 fi
+echo "Adding ${ARTIFACT_COUNT} artifact(s) to releaseNotes.content.artifacts"
 
 TMP_DATA="$(mktemp)"
 jq --argjson artifacts "${DEDUPED}" '

--- a/utils/scripts/npm-pulp-upload
+++ b/utils/scripts/npm-pulp-upload
@@ -9,7 +9,7 @@
 #   PULP_REPOSITORY      npm repository name (required)
 #   PULP_FILE_REPOSITORY Optional file repo for *.tl-compliance.json sidecars
 #
-# Credentials: /etc/service-account-secret/{username,password}
+# Credentials: ${SECRET_DIR:-/etc/service-account-secret}/{username,password}
 #
 set -euo pipefail
 
@@ -19,6 +19,7 @@ PULP_API_ROOT="${PULP_API_ROOT:-/api/}"
 PULP_DOMAIN="${PULP_DOMAIN:?PULP_DOMAIN required}"
 PULP_REPOSITORY="${PULP_REPOSITORY:?PULP_REPOSITORY required}"
 PULP_FILE_REPOSITORY="${PULP_FILE_REPOSITORY:-}"
+SECRET_DIR="${SECRET_DIR:-/etc/service-account-secret}"
 
 # shellcheck source=npm-common.sh
 _SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
@@ -40,18 +41,20 @@ readonly MAX_PACKAGE_JSON_BYTES=1048576  # 1 MiB
 readonly MAX_COMPLIANCE_SIDECAR_BYTES=1048576  # 1 MiB
 
 
-# Empty / missing FILES_DIR is a successful no-op (infra-only snapshots).
-# Skip Pulp auth/API entirely when there is nothing to upload.
-mkdir -p "${FILES_DIR}"
+# Require at least one .tgz (PAC packages/ filters avoid empty releases).
+if [[ ! -d "${FILES_DIR}" ]]; then
+  echo "ERROR: FILES_DIR does not exist: ${FILES_DIR}" >&2
+  exit 1
+fi
 ls -la "${FILES_DIR}"
 tgz_count="$(find "${FILES_DIR}" -type f -name '*.tgz' | wc -l)"
 if [[ "${tgz_count}" -eq 0 ]]; then
-  echo "No .tgz packages under ${FILES_DIR}; skipping Pulp upload (infra-only no-op)"
-  exit 0
+  echo "ERROR: No .tgz packages under ${FILES_DIR}" >&2
+  exit 1
 fi
 
-PULP_USER="$(< /etc/service-account-secret/username)"
-PULP_PASS="$(< /etc/service-account-secret/password)"
+PULP_USER="$(< "${SECRET_DIR}/username")"
+PULP_PASS="$(< "${SECRET_DIR}/password")"
 
 # Normalize so "/api" and "/api/" both yield ".../api/pulp/..."
 PULP_API_ROOT_NORM="${PULP_API_ROOT%/}/"

--- a/utils/scripts/npm-release-extract
+++ b/utils/scripts/npm-release-extract
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Release-pipeline entrypoint: snapshot → extract npm OCI → release notes →
+# Chains provenance. Invoked as a single Tekton step via:
+#   command: ["npm-release-extract"]
+#
+# Env (from task stepTemplate):
+#   TRUSTED_ARTIFACTS_EXTRACT_DIR  Workdir root (dataDir)
+#   SNAPSHOT_PATH                  Snapshot JSON path relative to extract dir
+#   IMAGES_TXT                     Output list of digest-pinned images
+#   FILES_DIR                      Extract root for oras pulls
+#   DATA_FILE                      data.json for release notes
+#   TRUSTED_PROVENANCE_NAMESPACES  Optional (passed through to fetch)
+#   ORAS_OPTIONS                   Optional (passed through to extract)
+#   STATUS_PATH                    Optional Tekton results.status path
+#
+set -euo pipefail
+
+_SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+if [[ -f "${_SCRIPT_DIR}/npm-common.sh" ]]; then
+  # shellcheck disable=SC1091
+  source "${_SCRIPT_DIR}/npm-common.sh"
+else
+  # shellcheck disable=SC1091
+  source "$(command -v npm-common.sh)"
+fi
+
+TRUSTED_ARTIFACTS_EXTRACT_DIR="${TRUSTED_ARTIFACTS_EXTRACT_DIR:?TRUSTED_ARTIFACTS_EXTRACT_DIR required}"
+SNAPSHOT_PATH="${SNAPSHOT_PATH:?SNAPSHOT_PATH required}"
+IMAGES_TXT="${IMAGES_TXT:?IMAGES_TXT required}"
+FILES_DIR="${FILES_DIR:?FILES_DIR required}"
+DATA_FILE="${DATA_FILE:?DATA_FILE required}"
+
+SNAPSHOT_FILE="${TRUSTED_ARTIFACTS_EXTRACT_DIR}/${SNAPSHOT_PATH}"
+if [[ ! -f "${SNAPSHOT_FILE}" ]]; then
+  fail_with_status "snapshot not found: ${SNAPSHOT_FILE}"
+fi
+
+if ! jq -e '.components | type == "array"' "${SNAPSHOT_FILE}" >/dev/null 2>&1; then
+  fail_with_status "snapshot missing components array: ${SNAPSHOT_FILE}"
+fi
+
+jq -r '
+  .components[]?
+  | select(.containerImage != null and .containerImage != "")
+  | .containerImage
+' "${SNAPSHOT_FILE}" > "${IMAGES_TXT}"
+
+if [[ ! -s "${IMAGES_TXT}" ]]; then
+  fail_with_status "no containerImage entries in snapshot: ${SNAPSHOT_FILE}"
+fi
+
+echo "Snapshot images:"
+cat "${IMAGES_TXT}"
+
+npm-extract-artifacts || fail_with_status "npm-extract-artifacts failed"
+npm-populate-release-notes || fail_with_status "npm-populate-release-notes failed"
+npm-fetch-chains-provenance || fail_with_status "npm-fetch-chains-provenance failed"
+
+echo "npm-release-extract completed"

--- a/utils/scripts/npm-release-upload
+++ b/utils/scripts/npm-release-upload
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Release-pipeline entrypoint: validate Pulp credentials and upload npm .tgz.
+# Invoked as a single Tekton step via:
+#   command: ["npm-release-upload"]
+#
+# Env (from task stepTemplate):
+#   FILES_DIR, PULP_*, STATUS_PATH (optional)
+# Credentials: /etc/service-account-secret/{username,password}
+#
+set -euo pipefail
+
+_SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+if [[ -f "${_SCRIPT_DIR}/npm-common.sh" ]]; then
+  # shellcheck disable=SC1091
+  source "${_SCRIPT_DIR}/npm-common.sh"
+else
+  # shellcheck disable=SC1091
+  source "$(command -v npm-common.sh)"
+fi
+
+SECRET_DIR="${SECRET_DIR:-/etc/service-account-secret}"
+
+for name in username password; do
+  path="${SECRET_DIR}/${name}"
+  if [[ ! -f "${path}" ]] || [[ -z "$(tr -d '[:space:]' < "${path}")" ]]; then
+    fail_with_status "Pulp credential missing or empty: ${path}"
+  fi
+done
+
+npm-pulp-upload || fail_with_status "npm-pulp-upload failed"
+
+echo "npm-release-upload completed"

--- a/utils/tests/run_tests.sh
+++ b/utils/tests/run_tests.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# Unit tests for plumbing-utils npm release scripts.
+# Run from repo:  ./utils/tests/run_tests.sh
+# Or via Containerfile test stage.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/.." && pwd)"
+SCRIPTS="${ROOT}/scripts"
+export PATH="${SCRIPTS}:${PATH}"
+
+# shellcheck disable=SC1091
+source "${SCRIPTS}/npm-common.sh"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local got="$1" want="$2" msg="$3"
+  if [[ "${got}" == "${want}" ]]; then
+    echo "PASS: ${msg}"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: ${msg} (got='${got}' want='${want}')" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_ok() {
+  local msg="$1"
+  shift
+  if "$@"; then
+    echo "PASS: ${msg}"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: ${msg}" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_fail() {
+  local msg="$1"
+  shift
+  if "$@" >/dev/null 2>&1; then
+    echo "FAIL: ${msg} (expected failure)" >&2
+    FAIL=$((FAIL + 1))
+  else
+    echo "PASS: ${msg}"
+    PASS=$((PASS + 1))
+  fi
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+# --- assert_tar_member_size ---
+pkgdir="${tmpdir}/pkg"
+mkdir -p "${pkgdir}/package"
+echo '{"name":"x","version":"1.0.0"}' > "${pkgdir}/package/package.json"
+tgz="${tmpdir}/x-1.0.0.tgz"
+tar -czf "${tgz}" -C "${pkgdir}" package
+assert_ok "assert_tar_member_size accepts package.json" \
+  assert_tar_member_size "${tgz}" "package/package.json" 1048576
+assert_fail "assert_tar_member_size rejects missing member" \
+  assert_tar_member_size "${tgz}" "package/missing.json" 1048576
+
+# --- write_status_error / fail_with_status ---
+status="${tmpdir}/status"
+STATUS_PATH="${status}" write_status_error "boom"
+assert_eq "$(cat "${status}")" "ERROR: boom" "write_status_error writes STATUS_PATH"
+
+# --- npm-populate-release-notes empty fails ---
+empty_files="${tmpdir}/empty-files"
+mkdir -p "${empty_files}"
+data="${tmpdir}/data.json"
+echo '{"releaseNotes":{"content":{}}}' > "${data}"
+assert_fail "npm-populate-release-notes fails with no .tgz" \
+  env FILES_DIR="${empty_files}" DATA_FILE="${data}" npm-populate-release-notes
+
+# --- npm-pulp-upload empty fails ---
+assert_fail "npm-pulp-upload fails with no .tgz" \
+  env FILES_DIR="${empty_files}" \
+      PULP_BASE_URL="https://example.invalid" \
+      PULP_DOMAIN="d" \
+      PULP_REPOSITORY="r" \
+      npm-pulp-upload
+
+# --- npm-release-upload missing secret fails ---
+sec="${tmpdir}/secret-empty"
+mkdir -p "${sec}"
+: > "${sec}/username"
+: > "${sec}/password"
+status2="${tmpdir}/status2"
+assert_fail "npm-release-upload fails on empty credentials" \
+  env SECRET_DIR="${sec}" STATUS_PATH="${status2}" \
+      FILES_DIR="${empty_files}" \
+      PULP_BASE_URL="https://example.invalid" \
+      PULP_DOMAIN="d" \
+      PULP_REPOSITORY="r" \
+      npm-release-upload
+[[ -f "${status2}" ]] && assert_eq "$(head -n1 "${status2}")" "ERROR: Pulp credential missing or empty: ${sec}/username" \
+  "npm-release-upload writes STATUS_PATH on credential failure" \
+  || { echo "FAIL: missing STATUS_PATH after credential failure"; FAIL=$((FAIL + 1)); }
+
+# --- npm-release-extract orchestration with PATH stubs ---
+stub_bin="${tmpdir}/stubs"
+mkdir -p "${stub_bin}"
+log="${tmpdir}/calls.log"
+: > "${log}"
+for cmd in npm-extract-artifacts npm-populate-release-notes npm-fetch-chains-provenance; do
+  cat > "${stub_bin}/${cmd}" <<EOF
+#!/usr/bin/env bash
+echo "${cmd}" >> "${log}"
+EOF
+  chmod +x "${stub_bin}/${cmd}"
+done
+
+workdir="${tmpdir}/workdir"
+mkdir -p "${workdir}"
+cat > "${workdir}/snapshot.json" <<'EOF'
+{
+  "components": [
+    {"containerImage": "quay.example/repo@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+    {"name": "skip-me"},
+    {"containerImage": "quay.example/repo2@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}
+  ]
+}
+EOF
+images_txt="${workdir}/images.txt"
+data2="${workdir}/data.json"
+echo '{}' > "${data2}"
+files_dir="${workdir}/files"
+mkdir -p "${files_dir}"
+
+assert_ok "npm-release-extract runs with stubbed children" \
+  env PATH="${stub_bin}:${SCRIPTS}:${PATH}" \
+      TRUSTED_ARTIFACTS_EXTRACT_DIR="${workdir}" \
+      SNAPSHOT_PATH="snapshot.json" \
+      IMAGES_TXT="${images_txt}" \
+      FILES_DIR="${files_dir}" \
+      DATA_FILE="${data2}" \
+      npm-release-extract
+
+assert_eq "$(wc -l < "${images_txt}" | tr -d ' ')" "2" "extract writes two image refs"
+assert_eq "$(tr '\n' ' ' < "${log}" | tr -s ' ')" \
+  "npm-extract-artifacts npm-populate-release-notes npm-fetch-chains-provenance " \
+  "extract calls children in order"
+
+# missing snapshot fails
+assert_fail "npm-release-extract fails without snapshot" \
+  env PATH="${stub_bin}:${SCRIPTS}:${PATH}" \
+      TRUSTED_ARTIFACTS_EXTRACT_DIR="${workdir}" \
+      SNAPSHOT_PATH="missing.json" \
+      IMAGES_TXT="${images_txt}" \
+      FILES_DIR="${files_dir}" \
+      DATA_FILE="${data2}" \
+      npm-release-extract
+
+# --- npm-pulp-upload digest match (skip) and digest conflict (fail) ---
+pulp_files="${tmpdir}/pulp-files"
+mkdir -p "${pulp_files}"
+cp "${tgz}" "${pulp_files}/lodash-4.17.21.tgz"
+# Rename package.json inside is already name x; rewrite tarball as lodash for upload
+pulp_pkg="${tmpdir}/lodash-pkg"
+mkdir -p "${pulp_pkg}/package"
+jq -nc '{name:"lodash",version:"4.17.21"}' > "${pulp_pkg}/package/package.json"
+lodash_tgz="${pulp_files}/lodash-4.17.21.tgz"
+tar -czf "${lodash_tgz}" -C "${pulp_pkg}" package
+local_sha="$(sha256sum "${lodash_tgz}" | awk '{print $1}')"
+
+# Shared mock curl for digest scenarios (state via MOCK_MODE env)
+mock_curl_bin="${tmpdir}/mock-curl"
+mkdir -p "${mock_curl_bin}"
+cat > "${mock_curl_bin}/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+joined="$*"
+# Repo list
+if [[ "${joined}" == *"/repositories/npm/npm/"* && "${joined}" != *"/content/"* ]]; then
+  echo '{"results":[{"name":"npm-registry","pulp_href":"/api/pulp/d/api/v3/repositories/npm/npm/r/","latest_version_href":"/api/pulp/d/api/v3/repositories/npm/npm/r/versions/1/"}]}'
+  exit 0
+fi
+# Content list
+if [[ "${joined}" == *"/content/npm/packages/"* && "${joined}" == *"--data-urlencode"* ]]; then
+  echo "{\"count\":1,\"results\":[{\"name\":\"lodash\",\"version\":\"4.17.21\",\"pulp_href\":\"/api/pulp/d/api/v3/content/npm/packages/x/\",\"artifact\":\"/api/pulp/d/api/v3/artifacts/${MOCK_REMOTE_SHA}/\",\"pulp_labels\":{}}]}"
+  exit 0
+fi
+# Artifact GET
+if [[ "${joined}" == *"/artifacts/"* ]]; then
+  echo "{\"sha256\":\"${MOCK_REMOTE_SHA}\"}"
+  exit 0
+fi
+# Label set (digest-match path still applies labels)
+if [[ "${joined}" == *"set_label/"* ]]; then
+  echo '{}'
+  exit 0
+fi
+# Upload should not be reached on match; allow on conflict path failures
+if [[ "${joined}" == *"/content/npm/packages/upload/"* ]]; then
+  echo "mock curl: unexpected upload" >&2
+  exit 22
+fi
+echo "mock curl: unhandled: ${joined}" >&2
+exit 22
+EOF
+chmod +x "${mock_curl_bin}/curl"
+
+sec_ok="${tmpdir}/secret-ok"
+mkdir -p "${sec_ok}"
+echo user > "${sec_ok}/username"
+echo pass > "${sec_ok}/password"
+
+assert_ok "npm-pulp-upload skips when remote sha256 matches" \
+  env PATH="${mock_curl_bin}:${PATH}" \
+      FILES_DIR="${pulp_files}" \
+      SECRET_DIR="${sec_ok}" \
+      PULP_BASE_URL="https://example.invalid" \
+      PULP_API_ROOT="/api/" \
+      PULP_DOMAIN="d" \
+      PULP_REPOSITORY="npm-registry" \
+      MOCK_REMOTE_SHA="${local_sha}" \
+      npm-pulp-upload
+
+assert_fail "npm-pulp-upload fails when remote sha256 conflicts" \
+  env PATH="${mock_curl_bin}:${PATH}" \
+      FILES_DIR="${pulp_files}" \
+      SECRET_DIR="${sec_ok}" \
+      PULP_BASE_URL="https://example.invalid" \
+      PULP_API_ROOT="/api/" \
+      PULP_DOMAIN="d" \
+      PULP_REPOSITORY="npm-registry" \
+      MOCK_REMOTE_SHA="0000000000000000000000000000000000000000000000000000000000000000" \
+      npm-pulp-upload
+
+echo
+echo "Results: ${PASS} passed, ${FAIL} failed"
+[[ "${FAIL}" -eq 0 ]]


### PR DESCRIPTION
These are the changes here:

- Remove all logic about infra-only changes. Filtering in npm-registry PLRs based on path.
- Add driver scripts to satisfy RSC requirements to have single step single command requirement

## Summary by Sourcery

Enforce npm OCI workflows to operate only on real package artifacts and add driver scripts plus utilities and tests to support single-command release tasks on RSC.

New Features:
- Introduce driver scripts for npm release orchestration, including extraction and upload workflows suitable for single-command RSC tasks.

Bug Fixes:
- Prevent npm OCI build and promote tasks from producing or pushing empty placeholder artifacts by requiring at least one .tgz package.
- Fail npm promote and related tasks when package status is not has-packages, relying on upstream path filters for infra-only merges.

Enhancements:
- Add helper functions in npm-common.sh to consistently record error status for Tekton result outputs.
- Strengthen npm OCI promote and build tasks with additional validation for presence of package tarballs before pushing artifacts.

Build:
- Extend the utils container build to include a dedicated test stage that runs script unit tests and gates the final image on passing tests.
- Ensure installed utility scripts in the image are executable via a chmod step.

Tests:
- Add a bash-based unit test suite for npm release plumbing scripts, covering error handling, orchestration behavior, and Pulp interaction edge cases.