### PR TITLE
Fixing oras images not having find command

### DIFF
--- a/tasks/build-npm-package-oci-ta.yaml
+++ b/tasks/build-npm-package-oci-ta.yaml
@@ -176,14 +176,15 @@ spec:
           echo "No npm artifacts to push under ${PUSH_DIR}" >&2
           exit 1
         fi
-        # Require at least one package tarball (no .keep placeholders).
-        mapfile -t tgz_found < <(find . -type f -name '*.tgz' | head -n 1)
+        # Require at least one package tarball (oras image has no find(1)).
+        shopt -s nullglob globstar
+        tgz_found=(*.tgz **/*.tgz)
         if [[ ${#tgz_found[@]} -eq 0 ]]; then
           echo "No .tgz packages to push (refusing empty / placeholder OCI)" >&2
           ls -la >&2 || true
           exit 1
         fi
-        shopt -u dotglob
+        shopt -u nullglob globstar dotglob
 
         echo "Pushing OCI artifact to ${IMAGE}"
         if ! retry oras push "$IMAGE" \

--- a/tasks/promote-npm-oci-ta.yaml
+++ b/tasks/promote-npm-oci-ta.yaml
@@ -148,11 +148,15 @@ spec:
           exit 1
         fi
 
-        if ! find "${ARTIFACT_ROOT}" -type f -name '*.tgz' | grep -q .; then
+        # oras image has no find(1).
+        shopt -s nullglob globstar
+        tgz_found=("${ARTIFACT_ROOT}"/*.tgz "${ARTIFACT_ROOT}"/**/*.tgz)
+        if [[ ${#tgz_found[@]} -eq 0 ]]; then
           echo "ERROR: pulled ${SOURCE_IMAGE} but found no .tgz under ${ARTIFACT_ROOT}" >&2
           ls -la "${ARTIFACT_ROOT}" >&2 || true
           exit 1
         fi
+        shopt -u nullglob globstar
 
         echo -n "${SOURCE_IMAGE}" | tee "$(results.SOURCE_IMAGE.path)"
         ls -la "${ARTIFACT_ROOT}"
@@ -237,13 +241,15 @@ spec:
           echo "No artifacts to push after promote staging" >&2
           exit 1
         fi
-        mapfile -t tgz_found < <(find . -type f -name '*.tgz' | head -n 1)
+        # Require at least one package tarball (oras image has no find(1)).
+        shopt -s nullglob globstar
+        tgz_found=(*.tgz **/*.tgz)
         if [[ ${#tgz_found[@]} -eq 0 ]]; then
           echo "No .tgz packages to push (refusing empty / placeholder OCI)" >&2
           ls -la >&2 || true
           exit 1
         fi
-        shopt -u dotglob
+        shopt -u nullglob globstar dotglob
 
         echo "Pushing OCI artifact to ${IMAGE}"
         if ! retry oras push "$IMAGE" \


### PR DESCRIPTION
When pushing OCI we first check there are packages to push. However, oras image has no find command

## Summary by Sourcery

Ensure OCI promotion and build tasks correctly detect .tgz package artifacts in environments where the oras image lacks the find command.

Bug Fixes:
- Replace use of find with Bash globbing to detect .tgz package files so OCI tasks work with oras images that do not provide find.
- Tighten shell option handling around globbing when checking for package tarballs in OCI-related Tekton tasks.