### PR TITLE
Restore auth credentials for builder wheel cache access

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -161,6 +161,8 @@ spec:
       workspaces:
         - name: git-basic-auth
           workspace: git-auth
+        - name: netrc
+          workspace: netrc
     - name: build-container
       params:
         - name: IMAGE
@@ -565,4 +567,6 @@ spec:
             - "false"
   workspaces:
     - name: git-auth
+      optional: true
+    - name: netrc
       optional: true

--- a/.tekton/bundle-build-pipeline.yaml
+++ b/.tekton/bundle-build-pipeline.yaml
@@ -154,6 +154,8 @@ spec:
       workspaces:
         - name: git-basic-auth
           workspace: git-auth
+        - name: netrc
+          workspace: netrc
     - name: build-container
       params:
         - name: IMAGE
@@ -282,4 +284,6 @@ spec:
         resolver: bundles
   workspaces:
     - name: git-auth
+      optional: true
+    - name: netrc
       optional: true

--- a/builder/scripts/build-wheels
+++ b/builder/scripts/build-wheels
@@ -127,6 +127,20 @@ if [ -f "$ca_bundle" ]; then
     update-ca-trust
 fi
 
+log "Setting up netrc"
+NETRC=~/.netrc
+
+# Only write netrc if both SERVICE_ACCOUNT_USERNAME and SERVICE_ACCOUNT_PASSWORD are set.
+if [ -n "${SERVICE_ACCOUNT_USERNAME:-}" ] && [ -n "${SERVICE_ACCOUNT_PASSWORD:-}" ]; then
+    cat > "$NETRC" <<- EOM
+machine packages.redhat.com login ${SERVICE_ACCOUNT_USERNAME} password ${SERVICE_ACCOUNT_PASSWORD}
+EOM
+    chmod 0600 "$NETRC"
+    log "Wrote netrc for packages.redhat.com"
+else
+    log "SERVICE_ACCOUNT_USERNAME and/or SERVICE_ACCOUNT_PASSWORD not set - skipping netrc setup"
+fi
+
 log "Preparing build environment"
 rm -rf output
 mkdir output

--- a/tasks/build-python-wheels-oci-ta.yaml
+++ b/tasks/build-python-wheels-oci-ta.yaml
@@ -42,6 +42,11 @@ spec:
       description: Optional wheel server URL for prebuilt wheel lookup
       type: string
       default: ""
+    - name: SERVICE_ACCOUNT_SECRET_NAME
+      description: >-
+        Name of the K8s secret containing wheel cache server credentials (keys: username, password)
+      type: string
+      default: builder-service-account
     - name: PACKAGE_SETTINGS_DIR
       description: Optional directory of per-package fromager settings (e.g. build_dir for monorepo packages)
       type: string
@@ -99,6 +104,17 @@ spec:
         - mountPath: /mnt/trusted-ca
           name: trusted-ca
           readOnly: true
+      env:
+        - name: SERVICE_ACCOUNT_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: $(params.SERVICE_ACCOUNT_SECRET_NAME)
+              key: username
+        - name: SERVICE_ACCOUNT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: $(params.SERVICE_ACCOUNT_SECRET_NAME)
+              key: password
       args:
         - $(params.CONSTRAINT_FILES[*])
         - --


### PR DESCRIPTION
Re-add the SERVICE_ACCOUNT_SECRET_NAME parameter, secret env vars in the build task, netrc setup in build-wheels, and netrc workspace declarations in pipelines. This reverts the removal in 655a54e in preparation for re-requiring authentication on the index.

## Summary by Sourcery

Restore wheel cache authentication configuration across build tasks and pipelines.

Bug Fixes:
- Restore authentication credentials for wheel cache access during Python wheel builds.

Enhancements:
- Reintroduce optional netrc workspace support in the standard and bundle build pipelines.