### PR TITLE
Updating assess npm compliance to check from pakages.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .vscode
 venv/
 .env
+__pycache__/
+*.py[cod]

--- a/hack/npm-pulp-api-probe.sh
+++ b/hack/npm-pulp-api-probe.sh
@@ -1,0 +1,345 @@
+#!/usr/bin/env bash
+# Drive the production npm-pulp-upload REST path against a live Pulp.
+#
+# Same API + labels as plumbing utils/scripts/npm-pulp-upload (what RSC
+# upload-npm-pulp runs after the plumbing-utils image pin):
+#   GET  .../repositories/npm/npm/?name=<repo>
+#   GET  .../content/npm/packages/?name=&repository_version=  (no version=)
+#   POST .../content/npm/packages/upload/   file, name, version, pulp_labels
+#                                          (no repository)
+#   POST {repo_href}modify/                 {"add_content_units":[href]}
+#   GET  {task} until state=completed
+# Label key: tl.compliance_level  (from adjacent *.tl-compliance.json)
+#
+# Defaults match the merged calunga-push-npm-to-pulp-prod RPA.
+#
+# Example:
+#   export PULP_USERNAME='...'
+#   export PULP_PASSWORD='...'
+#   ./hack/npm-pulp-api-probe.sh --package /path/to/express-4.22.0.tgz
+#
+# macOS: npm-pulp-upload uses GNU `readlink -f`. Install coreutils and this
+# probe will prepend it to PATH:
+#   brew install coreutils
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UPLOAD_SCRIPT="${SCRIPT_DIR}/../utils/scripts/npm-pulp-upload"
+
+# npm-pulp-upload uses GNU `readlink -f`; this probe also needs `sha256sum`.
+# On macOS, Homebrew coreutils puts those on PATH under libexec/gnubin.
+ensure_gnu_coreutils_path() {
+  if readlink -f / >/dev/null 2>&1 && command -v sha256sum >/dev/null 2>&1; then
+    return 0
+  fi
+  local prefixes=()
+  local p
+  prefixes+=(
+    /opt/homebrew/opt/coreutils/libexec/gnubin
+    /usr/local/opt/coreutils/libexec/gnubin
+  )
+  if command -v brew >/dev/null 2>&1; then
+    p="$(brew --prefix coreutils 2>/dev/null || true)"
+    if [[ -n "${p}" ]]; then
+      prefixes+=("${p}/libexec/gnubin")
+    fi
+  fi
+  for p in "${prefixes[@]}"; do
+    if [[ -x "${p}/readlink" ]]; then
+      export PATH="${p}:${PATH}"
+      if readlink -f / >/dev/null 2>&1; then
+        echo "Using GNU coreutils from ${p}"
+        return 0
+      fi
+    fi
+  done
+  cat >&2 <<'EOF'
+ERROR: GNU coreutils are required (readlink -f, sha256sum).
+macOS ships BSD readlink, which has no -f.
+
+Install and retry:
+
+  brew install coreutils
+
+This probe prepends $(brew --prefix coreutils)/libexec/gnubin to PATH when that
+directory exists. You can also add it to your shell profile.
+EOF
+  exit 1
+}
+
+# Merged RPA: config/.../ReleasePlanAdmission/calunga/calunga-push-npm-to-pulp-prod.yaml
+PULP_BASE_URL="${PULP_BASE_URL:-https://packages.redhat.com}"
+PULP_API_ROOT="${PULP_API_ROOT:-/api/}"
+PULP_DOMAIN="${PULP_DOMAIN:-public-trusted-libraries}"
+PULP_REPOSITORY="${PULP_REPOSITORY:-npm-registry}"
+# Production pipeline omits fileRepository (labels only).
+PULP_FILE_REPOSITORY="${PULP_FILE_REPOSITORY:-}"
+
+PACKAGE=""
+COMPLIANCE_LEVEL="L1"
+USERNAME="${PULP_USERNAME:-}"
+PASSWORD="${PULP_PASSWORD:-}"
+PASSWORD_FILE=""
+SECRET_DIR_IN=""
+VERIFY_ONLY=false
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") --package FILE [options]
+
+Upload one npm .tgz through the same Pulp REST sequence RSC/plumbing use.
+
+Required:
+  --package, -f FILE         Path to a .tgz (e.g. express-4.22.0.tgz)
+
+Credentials (first match wins):
+  --secret-dir DIR           Tekton-style dir with username and password files
+  --username, -u NAME        Or env PULP_USERNAME
+  --password-file FILE       File containing the password (preferred over -p)
+  --password, -p PASS        Or env PULP_PASSWORD (visible in ps / shell history)
+
+Options:
+  --compliance-level LEVEL   L1, L2, or L3 (default: L1). Writes the same
+                             *.tl-compliance.json sidecar npm-pulp-upload reads
+                             and sets pulp_labels tl.compliance_level.
+  --no-label                 Do not send a compliance label (no sidecar).
+  --verify-only              Skip upload; only list name@version in the repo.
+  --base-url URL             default: ${PULP_BASE_URL}
+  --api-root PATH            default: ${PULP_API_ROOT}
+  --domain NAME              default: ${PULP_DOMAIN}
+  --repository NAME          default: ${PULP_REPOSITORY}
+  -h, --help
+
+PULP_FILE_REPOSITORY is left empty unless you export it, matching production.
+
+macOS: brew install coreutils
+  (GNU readlink -f; this script prepends coreutils to PATH when needed)
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    --package|-f)
+      [[ $# -lt 2 ]] && { echo "ERROR: $1 requires a value" >&2; exit 1; }
+      PACKAGE="$2"; shift 2 ;;
+    --compliance-level)
+      [[ $# -lt 2 ]] && { echo "ERROR: $1 requires a value" >&2; exit 1; }
+      COMPLIANCE_LEVEL="$2"; shift 2 ;;
+    --no-label) COMPLIANCE_LEVEL=""; shift ;;
+    --verify-only) VERIFY_ONLY=true; shift ;;
+    --username|-u)
+      [[ $# -lt 2 ]] && { echo "ERROR: $1 requires a value" >&2; exit 1; }
+      USERNAME="$2"; shift 2 ;;
+    --password|-p)
+      [[ $# -lt 2 ]] && { echo "ERROR: $1 requires a value" >&2; exit 1; }
+      PASSWORD="$2"; shift 2 ;;
+    --password-file)
+      [[ $# -lt 2 ]] && { echo "ERROR: $1 requires a value" >&2; exit 1; }
+      PASSWORD_FILE="$2"; shift 2 ;;
+    --secret-dir)
+      [[ $# -lt 2 ]] && { echo "ERROR: $1 requires a value" >&2; exit 1; }
+      SECRET_DIR_IN="$2"; shift 2 ;;
+    --base-url)
+      [[ $# -lt 2 ]] && { echo "ERROR: $1 requires a value" >&2; exit 1; }
+      PULP_BASE_URL="$2"; shift 2 ;;
+    --api-root)
+      [[ $# -lt 2 ]] && { echo "ERROR: $1 requires a value" >&2; exit 1; }
+      PULP_API_ROOT="$2"; shift 2 ;;
+    --domain)
+      [[ $# -lt 2 ]] && { echo "ERROR: $1 requires a value" >&2; exit 1; }
+      PULP_DOMAIN="$2"; shift 2 ;;
+    --repository)
+      [[ $# -lt 2 ]] && { echo "ERROR: $1 requires a value" >&2; exit 1; }
+      PULP_REPOSITORY="$2"; shift 2 ;;
+    --)
+      shift; break ;;
+    -*)
+      echo "ERROR: unknown option $1" >&2
+      usage >&2
+      exit 1 ;;
+    *)
+      if [[ -n "${PACKAGE}" ]]; then
+        echo "ERROR: unexpected argument '$1'" >&2
+        exit 1
+      fi
+      PACKAGE="$1"
+      shift ;;
+  esac
+done
+
+if [[ -z "${PACKAGE}" ]]; then
+  echo "ERROR: --package is required" >&2
+  usage >&2
+  exit 1
+fi
+if [[ ! -f "${PACKAGE}" ]]; then
+  echo "ERROR: package not found: ${PACKAGE}" >&2
+  exit 1
+fi
+if [[ "${PACKAGE}" != *.tgz ]]; then
+  echo "ERROR: package must be a .tgz: ${PACKAGE}" >&2
+  exit 1
+fi
+if [[ -n "${COMPLIANCE_LEVEL}" && ! "${COMPLIANCE_LEVEL}" =~ ^L[123]$ ]]; then
+  echo "ERROR: --compliance-level must be L1, L2, or L3 (got '${COMPLIANCE_LEVEL}')" >&2
+  exit 1
+fi
+if [[ ! -f "${UPLOAD_SCRIPT}" ]]; then
+  echo "ERROR: production uploader not found: ${UPLOAD_SCRIPT}" >&2
+  exit 1
+fi
+
+ensure_gnu_coreutils_path
+
+for cmd in jq curl tar sha256sum; do
+  if ! command -v "${cmd}" >/dev/null 2>&1; then
+    echo "ERROR: required command not found: ${cmd}" >&2
+    exit 1
+  fi
+done
+
+if ! pkg_json="$(tar -xOf "${PACKAGE}" package/package.json 2>/dev/null)"; then
+  echo "ERROR: ${PACKAGE} has no package/package.json" >&2
+  exit 1
+fi
+PKG_NAME="$(jq -r '.name // empty' <<<"${pkg_json}")"
+PKG_VERSION="$(jq -r '.version // empty' <<<"${pkg_json}")"
+if [[ -z "${PKG_NAME}" || -z "${PKG_VERSION}" ]]; then
+  echo "ERROR: package.json missing name/version" >&2
+  exit 1
+fi
+LOCAL_SHA="$(sha256sum "${PACKAGE}" | awk '{print $1}')"
+
+if [[ -n "${PASSWORD_FILE}" ]]; then
+  PASSWORD="$(< "${PASSWORD_FILE}")"
+fi
+
+workdir="$(mktemp -d "${TMPDIR:-/tmp}/npm-pulp-api-probe.XXXXXX")"
+cleanup() { rm -rf "${workdir}"; }
+trap cleanup EXIT
+umask 077
+
+if [[ -n "${SECRET_DIR_IN}" ]]; then
+  SECRET_DIR="${SECRET_DIR_IN}"
+else
+  if [[ -z "${USERNAME}" || -z "${PASSWORD}" ]]; then
+    echo "ERROR: provide --secret-dir, or username + password" >&2
+    echo "       (--username/--password-file, or PULP_USERNAME/PULP_PASSWORD)" >&2
+    exit 1
+  fi
+  SECRET_DIR="${workdir}/secret"
+  mkdir -p "${SECRET_DIR}"
+  printf '%s' "${USERNAME}" > "${SECRET_DIR}/username"
+  printf '%s' "${PASSWORD}" > "${SECRET_DIR}/password"
+fi
+
+files_dir="${workdir}/files"
+mkdir -p "${files_dir}"
+base="$(basename "${PACKAGE}")"
+cp "${PACKAGE}" "${files_dir}/${base}"
+if [[ -n "${COMPLIANCE_LEVEL}" ]]; then
+  sidecar="${files_dir}/${base%.tgz}.tl-compliance.json"
+  jq -nc --arg lvl "${COMPLIANCE_LEVEL}" '{compliance_level: $lvl}' > "${sidecar}"
+fi
+
+api_root_norm="${PULP_API_ROOT%/}/"
+query_base="${PULP_BASE_URL}${api_root_norm}pulp/${PULP_DOMAIN}/api/v3/"
+
+echo "Destination (RPA defaults unless overridden)"
+echo "  base URL:    ${PULP_BASE_URL}"
+echo "  domain:      ${PULP_DOMAIN}"
+echo "  repository:  ${PULP_REPOSITORY}"
+echo "  file repo:   ${PULP_FILE_REPOSITORY:-<unset, labels only>}"
+echo "Package"
+echo "  file:        ${PACKAGE}"
+echo "  name:        ${PKG_NAME}@${PKG_VERSION}"
+echo "  sha256:      ${LOCAL_SHA}"
+echo "  label:       ${COMPLIANCE_LEVEL:-<none>}"
+echo "API sequence"
+echo "  GET  ${query_base}repositories/npm/npm/?name=${PULP_REPOSITORY}"
+echo "  GET  ${query_base}content/npm/packages/?name=${PKG_NAME}&repository_version=..."
+echo "  POST ${query_base}content/npm/packages/upload/  (file,name,version[,pulp_labels]; no repository)"
+echo "  POST {repo_href}modify/  {\"add_content_units\":[content_href]}"
+echo "  GET  {task} until completed"
+echo
+
+verify_in_repo() {
+  local user pass auth repo_json repo_href repo_ver list_json match
+  user="$(< "${SECRET_DIR}/username")"
+  pass="$(< "${SECRET_DIR}/password")"
+  auth=(-u "${user}:${pass}")
+
+  repo_json="$(curl --fail-with-body --silent --retry 3 --max-time 30 \
+    -G "${auth[@]}" \
+    "${query_base}repositories/npm/npm/" \
+    --data-urlencode "name=${PULP_REPOSITORY}")"
+  repo_href="$(jq -r '.results[0].pulp_href // empty' <<<"${repo_json}")"
+  repo_ver="$(jq -r '.results[0].latest_version_href // empty' <<<"${repo_json}")"
+  if [[ -z "${repo_href}" || -z "${repo_ver}" ]]; then
+    echo "ERROR: repository ${PULP_REPOSITORY} not found" >&2
+    echo "${repo_json}" >&2
+    return 1
+  fi
+  echo "Repository ${repo_href}"
+  echo "Version    ${repo_ver}"
+
+  list_json="$(curl --fail-with-body --silent --retry 3 --max-time 30 \
+    -G "${auth[@]}" \
+    "${query_base}content/npm/packages/" \
+    --data-urlencode "name=${PKG_NAME}" \
+    --data-urlencode "repository_version=${repo_ver}" \
+    --data-urlencode "limit=100" \
+    --data-urlencode "offset=0")"
+  if jq -e '(.errors | type) == "array" and (.errors | length) > 0' \
+    <<<"${list_json}" >/dev/null 2>&1; then
+    echo "ERROR: package list rejected (do not send version= as a filter)" >&2
+    echo "${list_json}" >&2
+    return 1
+  fi
+
+  match="$(jq -c --arg name "${PKG_NAME}" --arg version "${PKG_VERSION}" '
+    [.results[]?
+      | select((.name // "") == $name and (.version // "") == $version)
+    ] | if length == 1 then .[0] else empty end
+  ' <<<"${list_json}")"
+  if [[ -z "${match}" ]]; then
+    echo "VERIFY FAIL: ${PKG_NAME}@${PKG_VERSION} is not in ${PULP_REPOSITORY}" >&2
+    echo "Other ${PKG_NAME} versions in this repository version:" >&2
+    jq -r '.results[]? | "  - \(.name)@\(.version)  \(.pulp_href)"' \
+      <<<"${list_json}" >&2
+    return 1
+  fi
+
+  echo "Found ${PKG_NAME}@${PKG_VERSION}:"
+  jq . <<<"${match}"
+
+  local label
+  label="$(jq -r '.pulp_labels["tl.compliance_level"] // empty' <<<"${match}")"
+  if [[ -n "${COMPLIANCE_LEVEL}" && "${label}" != "${COMPLIANCE_LEVEL}" ]]; then
+    echo "VERIFY FAIL: expected pulp_labels.tl.compliance_level=${COMPLIANCE_LEVEL}," \
+      "got '${label:-<missing>}'" >&2
+    return 1
+  fi
+  echo "VERIFY OK: ${PKG_NAME}@${PKG_VERSION} in ${PULP_REPOSITORY}" \
+    "label=${label:-<none>}"
+}
+
+if [[ "${VERIFY_ONLY}" == true ]]; then
+  verify_in_repo
+  exit 0
+fi
+
+export FILES_DIR="${files_dir}"
+export SECRET_DIR
+export PULP_BASE_URL PULP_API_ROOT PULP_DOMAIN PULP_REPOSITORY
+export PULP_FILE_REPOSITORY
+export PULP_TASK_POLL_SECONDS="${PULP_TASK_POLL_SECONDS:-5}"
+export PULP_TASK_TIMEOUT_SECONDS="${PULP_TASK_TIMEOUT_SECONDS:-300}"
+
+echo "=== npm-pulp-upload (production script) ==="
+"${UPLOAD_SCRIPT}"
+echo
+echo "=== verify package is in the repository ==="
+verify_in_repo

--- a/npm-builder/Containerfile
+++ b/npm-builder/Containerfile
@@ -7,7 +7,7 @@ ARG SYFT_IMAGE=registry.redhat.io/rh-syft-tech-preview/syft-rhel9:1.29.0-1756223
 
 FROM ${SYFT_IMAGE} AS syft-bin
 
-FROM ${BASEIMAGE}
+FROM ${BASEIMAGE} AS tools
 
 LABEL maintainer="Red Hat Trusted Libraries"
 LABEL io.k8s.description="npm TL factory builder (Node 20, Go, Rust, glibc)"
@@ -65,6 +65,23 @@ RUN chmod +x /tmp/install-rust-toolset.sh && \
 COPY --from=syft-bin /usr/local/bin/syft /usr/local/bin/syft
 
 RUN useradd -m -u 1001 -s /bin/bash builder
+
+##########################
+# UNIT TESTS (must pass)
+##########################
+FROM tools AS test
+COPY scripts /src/scripts
+COPY tests /src/tests
+RUN chmod +x /src/scripts/* /src/tests/*.sh \
+    && /src/tests/run_tests.sh \
+    && touch /tmp/npm-builder-tests-ok
+
+##########################
+# ASSEMBLE THE FINAL IMAGE
+##########################
+FROM tools
+# Gate the final image on the unit-test stage.
+COPY --from=test /tmp/npm-builder-tests-ok /tmp/npm-builder-tests-ok
 
 COPY --chmod=755 scripts/shasum /usr/local/bin/shasum
 COPY --chmod=755 scripts/build-npm-package scripts/build-npm-packages scripts/collect-npm-artifacts scripts/collect-npm-package-outputs scripts/generate-npm-sbom scripts/verify-npm-sbom scripts/assess-npm-compliance scripts/lookup-npm-tl-compliance scripts/record-npm-packages-built scripts/npm-workdir-load.sh scripts/npm-publish-pulp /usr/local/bin/

--- a/npm-builder/README.md
+++ b/npm-builder/README.md
@@ -92,8 +92,8 @@ Local builds: `podman login registry.redhat.io` before `docker`/`podman` build.
 | `collect-npm-artifacts` | Stage `out/*.tgz` for OCI push / optional Pulp publish |
 | `generate-npm-sbom` | Syft → SPDX JSON embedded as `package/sboms/redhat.spdx.json` (Python parity) |
 | `verify-npm-sbom` | Promote: require embedded `redhat.spdx.json` in each `.tgz` |
-| `lookup-npm-tl-compliance` | Promote helper: public registry lookup for `name@version` level |
-| `assess-npm-compliance` | Promote: inductive L1/L2/L3 via manifests + `lookup-npm-tl-compliance`; write `*.tl-compliance.json` |
+| `lookup-npm-tl-compliance` | Promote helper: public packument lookup for `name` + version or range |
+| `assess-npm-compliance` | Promote: inductive L1/L2/L3 from packed `package.json` `dependencies` + `lookup-npm-tl-compliance`; write `*.tl-compliance.json` |
 | `npm-publish-pulp` | Optional Pulp npm publish (deferred; Tekton step only) |
 | `build_scripts/install-gcc-toolset.sh` | Install gcc-toolset from `gcc-toolset.lock` |
 | `build_scripts/install-rust-toolset.sh` | Install + versionlock pinned rust-toolset RPMs |
@@ -117,3 +117,15 @@ docker run --rm npm-builder rustc --version
 docker run --rm npm-builder cargo --version
 docker run --rm npm-builder syft version
 ```
+
+## Tests
+
+Konflux / `docker build` runs `tests/run_tests.sh` in a Containerfile stage and
+will not produce the final image if they fail (same pattern as `utils/`).
+
+```bash
+./npm-builder/tests/run_tests.sh
+```
+
+Local runs need bash 4+ (`mapfile`) and `sha256sum`. On macOS: `brew install bash coreutils`.
+

--- a/npm-builder/scripts/assess-npm-compliance
+++ b/npm-builder/scripts/assess-npm-compliance
@@ -2,13 +2,20 @@
 # Assess dependency-closure compliance against the public TL npm registry.
 # Writes *.tl-compliance.json sidecars next to each .tgz (outside the tarball).
 #
-# Inductive levels (no npm lockfile):
-#   L1 — one or more requires_tl_packages missing from TL
-#   L2 — all requires on TL, but at least one dep is L1 or L2
-#   L3 — no requires, OR every requires_tl_packages dep is itself L3
+# Direct production dependencies come from the packed package.json (what
+# consumers install), not from the onboarding manifest.
+#
+# Inductive levels (direct deps only; no npm lockfile):
+#   L1 — one or more packed dependencies missing from TL (range unsatisfied)
+#   L2 — all direct deps on TL, but at least one dep is L1 or L2
+#   L3 — no dependencies, OR every direct dep is itself L3
+#
+# optionalDependencies that are already in this snapshot (typically
+# @calunga/…-linux-x64 from the same recipe) are treated as satisfied and
+# are not part of the check. Other optionals and peerDependencies are ignored.
 #
 # Dep compliance is read from (in order): this OCI's sidecars / in-run levels,
-# then lookup-npm-tl-compliance (public registry + adjacent compliance JSON).
+# then lookup-npm-tl-compliance (public packument + adjacent compliance JSON).
 #
 # Usage:
 #   assess-npm-compliance [artifact-dir] [source-root] [package-dir ...]
@@ -56,8 +63,13 @@ if [[ ${#tarballs[@]} -eq 0 ]]; then
     exit 1
 fi
 
+# Split name@version where name may be scoped (@scope/pkg@1.2.3).
+nv_name() { printf '%s' "${1%@*}"; }
+nv_version() { printf '%s' "${1##*@}"; }
+
 declare -A LOCAL_TL=()
 declare -A TGZ_FOR=() # name@version → tarball path
+declare -A VERSIONS_FOR_NAME=() # name → space-separated versions
 for tgz in "${tarballs[@]}"; do
     if pkg_json="$(tar -xOf "${tgz}" package/package.json 2>/dev/null)"; then
         n="$(jq -r '.name // empty' <<<"${pkg_json}")"
@@ -65,6 +77,7 @@ for tgz in "${tarballs[@]}"; do
         if [[ -n "${n}" && -n "${v}" ]]; then
             LOCAL_TL["${n}@${v}"]=1
             TGZ_FOR["${n}@${v}"]="${tgz}"
+            VERSIONS_FOR_NAME["${n}"]="${VERSIONS_FOR_NAME[${n}]:-} ${v}"
         fi
     fi
 done
@@ -93,7 +106,7 @@ elif [[ -n "${SOURCE_DIR}" && -d "${SOURCE_DIR}" ]]; then
 fi
 
 if [[ ${#MANIFEST_PATHS[@]} -eq 0 ]]; then
-    echo "[assess-npm-compliance] no manifests found; cannot compute requires_tl_packages" >&2
+    echo "[assess-npm-compliance] no manifests found; cannot group outputs or record built_from" >&2
     echo "  Provide source-root (onboarding checkout) and optional package dirs." >&2
     exit 1
 fi
@@ -102,14 +115,25 @@ declare -A OUTPUT_TO_MANIFEST=()
 declare -A MANIFEST_REQUIRES=()
 declare -A MANIFEST_SOURCE_URL=()
 declare -A MANIFEST_SOURCE_REF=()
+declare -A MANIFEST_MAIN_KEY=()
+
+packed_direct_deps() {
+    local tgz="$1"
+    local pkg_json
+    pkg_json="$(tar -xOf "${tgz}" package/package.json)"
+    jq -c '
+      (.dependencies // {})
+      | to_entries
+      | map(select((.key | length) > 0 and (.value | type) == "string" and (.value | length) > 0))
+      | map({name: .key, requested: .value})
+    ' <<<"${pkg_json}"
+}
 
 for m in "${MANIFEST_PATHS[@]}"; do
     name="$(jq -r '.name' "${m}")"
     version="$(jq -r '.version' "${m}")"
-    requires="$(jq -c '.requires_tl_packages // []' "${m}")"
     src_url="$(jq -r '.source.url // empty' "${m}")"
     src_ref="$(jq -r '.source.ref // empty' "${m}")"
-    MANIFEST_REQUIRES["${m}"]="${requires}"
     MANIFEST_SOURCE_URL["${m}"]="${src_url}"
     MANIFEST_SOURCE_REF["${m}"]="${src_ref}"
 
@@ -118,41 +142,67 @@ for m in "${MANIFEST_PATHS[@]}"; do
         OUTPUT_TO_MANIFEST["${pulp_name}@${version}"]="${m}"
     done < <(jq -r '.outputs[].pulp_name // empty' "${m}")
     OUTPUT_TO_MANIFEST["${name}@${version}"]="${m}"
+
+    main_pulp="$(jq -r '[.outputs[] | select(.type == "npm-package") | .pulp_name][0] // .name' "${m}")"
+    main_key="${main_pulp}@${version}"
+    MANIFEST_MAIN_KEY["${m}"]="${main_key}"
+    if [[ -z "${TGZ_FOR[${main_key}]:-}" ]]; then
+        echo "[assess-npm-compliance] missing main tarball for ${main_key} (manifest ${m})" >&2
+        exit 1
+    fi
+    MANIFEST_REQUIRES["${m}"]="$(packed_direct_deps "${TGZ_FOR[${main_key}]}")"
 done
 
 # name@version → compliance level once known
 declare -A LEVELS=()
 
-# Returns 0 and prints level; exit 1 if missing from TL; exit 2 on transport error.
-lookup_dep_level() {
+resolve_local_version() {
     local pkg="$1"
-    local ver="$2"
-    local key="${pkg}@${ver}"
+    local spec="$2"
+    local versions="${VERSIONS_FOR_NAME[${pkg}]:-}"
+    # shellcheck disable=SC2086
+    lookup-npm-tl-compliance --max-satisfying "${spec}" ${versions}
+}
 
-    if [[ -n "${LEVELS[${key}]:-}" ]]; then
-        echo "${LEVELS[${key}]}"
-        return 0
-    fi
+# Returns 0 and prints JSON {name,requested,version,compliance_level};
+# exit 1 if missing from TL; exit 2 on transport error.
+lookup_dep() {
+    local pkg="$1"
+    local spec="$2"
+    local resolved rc json lvl key tgz base sidecar
 
-    # Sidecar already written in this artifact dir (same promote / prior output).
-    if [[ -n "${TGZ_FOR[${key}]:-}" ]]; then
-        local tgz="${TGZ_FOR[${key}]}"
-        local base sidecar lvl
-        base="$(basename "${tgz}" .tgz)"
-        sidecar="$(dirname "${tgz}")/${base}.tl-compliance.json"
-        if [[ -f "${sidecar}" ]]; then
-            lvl="$(jq -r '.compliance_level // empty' "${sidecar}")"
-            if [[ -n "${lvl}" ]]; then
-                LEVELS["${key}"]="${lvl}"
-                echo "${lvl}"
-                return 0
-            fi
+    set +e
+    resolved="$(resolve_local_version "${pkg}" "${spec}")"
+    rc=$?
+    set -e
+    if [[ "${rc}" -eq 0 && -n "${resolved}" ]]; then
+        key="${pkg}@${resolved}"
+        if [[ -n "${LEVELS[${key}]:-}" ]]; then
+            jq -nc --arg name "${pkg}" --arg requested "${spec}" \
+                --arg version "${resolved}" --arg compliance_level "${LEVELS[${key}]}" \
+                '{name:$name, requested:$requested, version:$version, compliance_level:$compliance_level}'
+            return 0
         fi
-        # Same OCI but not assessed yet — caller should topo-order; treat as pending miss.
-        return 1
+        if [[ -n "${TGZ_FOR[${key}]:-}" ]]; then
+            tgz="${TGZ_FOR[${key}]}"
+            base="$(basename "${tgz}" .tgz)"
+            sidecar="$(dirname "${tgz}")/${base}.tl-compliance.json"
+            if [[ -f "${sidecar}" ]]; then
+                lvl="$(jq -r '.compliance_level // empty' "${sidecar}")"
+                if [[ -n "${lvl}" ]]; then
+                    LEVELS["${key}"]="${lvl}"
+                    jq -nc --arg name "${pkg}" --arg requested "${spec}" \
+                        --arg version "${resolved}" --arg compliance_level "${lvl}" \
+                        '{name:$name, requested:$requested, version:$version, compliance_level:$compliance_level}'
+                    return 0
+                fi
+            fi
+            # Same OCI but not assessed yet — caller should topo-order; treat as pending miss.
+            return 1
+        fi
     fi
 
-    lookup-npm-tl-compliance "${TL_NPM_REGISTRY_URL}" "${pkg}" "${ver}"
+    lookup-npm-tl-compliance "${TL_NPM_REGISTRY_URL}" "${pkg}" "${spec}"
 }
 
 # Topological order of manifests: deps that appear in this OCI first.
@@ -169,7 +219,12 @@ for ((iter = 0; iter < max_iters; iter++)); do
         while IFS= read -r dep; do
             [[ -n "${dep}" ]] || continue
             dep_name="$(jq -r '.name' <<<"${dep}")"
-            dep_ver="$(jq -r '.version' <<<"${dep}")"
+            dep_spec="$(jq -r '.requested' <<<"${dep}")"
+            set +e
+            dep_ver="$(resolve_local_version "${dep_name}" "${dep_spec}")"
+            rc=$?
+            set -e
+            [[ "${rc}" -eq 0 && -n "${dep_ver}" ]] || continue
             dep_key="${dep_name}@${dep_ver}"
             if [[ -n "${TGZ_FOR[${dep_key}]:-}" && -z "${LEVELS[${dep_key}]:-}" ]]; then
                 dep_m="${OUTPUT_TO_MANIFEST[${dep_key}]:-}"
@@ -203,7 +258,7 @@ wrote=0
 assess_manifest() {
     local m="$1"
     local requires_json gaps_json gap_count level dep_levels_json
-    local dep dep_name dep_ver dep_key dep_level rc
+    local dep dep_name dep_spec dep_key dep_json dep_level dep_ver rc
     local key tgz base sha256 sidecar pkg_json out_name out_version
 
     requires_json="${MANIFEST_REQUIRES[${m}]}"
@@ -213,11 +268,10 @@ assess_manifest() {
     while IFS= read -r dep; do
         [[ -n "${dep}" ]] || continue
         dep_name="$(jq -r '.name' <<<"${dep}")"
-        dep_ver="$(jq -r '.version' <<<"${dep}")"
-        dep_key="${dep_name}@${dep_ver}"
+        dep_spec="$(jq -r '.requested' <<<"${dep}")"
 
         set +e
-        dep_level="$(lookup_dep_level "${dep_name}" "${dep_ver}")"
+        dep_json="$(lookup_dep "${dep_name}" "${dep_spec}")"
         rc=$?
         set -e
 
@@ -227,18 +281,22 @@ assess_manifest() {
         if [[ "${rc}" -ne 0 ]]; then
             gaps_json="$(jq -c --argjson gap "$(jq -n \
                 --arg name "${dep_name}" \
-                --arg version "${dep_ver}" \
-                '{name:$name, version:$version, reason:"not_on_tl_registry"}')" \
+                --arg requested "${dep_spec}" \
+                '{name:$name, requested:$requested, reason:"not_on_tl_registry"}')" \
                 '. + [$gap]' <<<"${gaps_json}")"
             continue
         fi
 
+        dep_ver="$(jq -r '.version' <<<"${dep_json}")"
+        dep_level="$(jq -r '.compliance_level' <<<"${dep_json}")"
+        dep_key="${dep_name}@${dep_ver}"
         LEVELS["${dep_key}"]="${dep_level}"
         dep_levels_json="$(jq -c --argjson row "$(jq -n \
             --arg name "${dep_name}" \
+            --arg requested "${dep_spec}" \
             --arg version "${dep_ver}" \
             --arg compliance_level "${dep_level}" \
-            '{name:$name, version:$version, compliance_level:$compliance_level}')" \
+            '{name:$name, requested:$requested, version:$version, compliance_level:$compliance_level}')" \
             '. + [$row]' <<<"${dep_levels_json}")"
     done < <(jq -c '.[]' <<<"${requires_json}")
 
@@ -272,8 +330,7 @@ assess_manifest() {
             --arg compliance_level "${level}" \
             --arg assessed_at "${assessed_at}" \
             --argjson closure_gaps "${gaps_json}" \
-            --argjson requires_tl_packages "${requires_json}" \
-            --argjson dependency_levels "${dep_levels_json}" \
+            --argjson direct_dependencies "${dep_levels_json}" \
             --arg src_url "${MANIFEST_SOURCE_URL[${m}]}" \
             --arg src_ref "${MANIFEST_SOURCE_REF[${m}]}" \
             --arg tarball "$(basename "${tgz}")" \
@@ -285,8 +342,7 @@ assess_manifest() {
               compliance_level: $compliance_level,
               assessed_at: $assessed_at,
               closure_gaps: $closure_gaps,
-              requires_tl_packages: $requires_tl_packages,
-              dependency_levels: $dependency_levels,
+              direct_dependencies: $direct_dependencies,
               built_from: (if $src_url == "" then null else {url: $src_url, ref: $src_ref} end),
               tarball: $tarball,
               tarball_sha256: $tarball_sha256,

--- a/npm-builder/scripts/lookup-npm-tl-compliance
+++ b/npm-builder/scripts/lookup-npm-tl-compliance
@@ -1,23 +1,304 @@
 #!/usr/bin/env python3
-"""Look up TL npm registry presence and compliance level for name@version.
+"""Look up TL npm registry presence and compliance level for a name + spec.
 
 Public registry only (no credentials). Used by assess-npm-compliance.
 
+The spec may be an exact version or an npm range (^1.5.0, ~1.2.3, >=1.0.0 <2).
+Ranges are resolved against the TL packument (highest matching version).
+
 Exit codes:
-  0 — print compliance level (L1/L2/L3) to stdout
-  1 — package/version not on TL registry
+  0 — print JSON {name, requested, version, compliance_level} to stdout
+  1 — package / matching version not on TL registry
   2 — transport / unexpected registry error
 
 Usage:
-  lookup-npm-tl-compliance <registry-base-url> <name> <version>
+  lookup-npm-tl-compliance <registry-base-url> <name> <version-or-range>
+  lookup-npm-tl-compliance --max-satisfying <spec> <version> [<version> ...]
 """
 from __future__ import print_function
 
 import json
+import re
 import sys
 import urllib.error
 import urllib.parse
 import urllib.request
+
+
+# --- npm-ish semver (exact, ^, ~, *, x-ranges, comparators, ||) ---
+
+_X = {"x", "X", "*"}
+
+
+def _cmp_pre_ids(a, b):
+    """npm: numeric identifiers compare numerically; others as strings."""
+    an = len(a)
+    bn = len(b)
+    for i in range(min(an, bn)):
+        ai, bi = a[i], b[i]
+        a_num, b_num = ai.isdigit(), bi.isdigit()
+        if a_num and b_num:
+            av, bv = int(ai), int(bi)
+            if av != bv:
+                return (av > bv) - (av < bv)
+        elif a_num != b_num:
+            return -1 if a_num else 1
+        else:
+            if ai != bi:
+                return (ai > bi) - (ai < bi)
+    return (an > bn) - (an < bn)
+
+
+class Version(object):
+    __slots__ = ("major", "minor", "patch", "prerelease")
+
+    def __init__(self, text):
+        raw = text.strip()
+        if raw.startswith("v") or raw.startswith("V"):
+            raw = raw[1:]
+        if "+" in raw:
+            raw = raw.split("+", 1)[0]
+        pre = None
+        if "-" in raw:
+            core, pre = raw.split("-", 1)
+        else:
+            core = raw
+        parts = core.split(".")
+        nums = []
+        for part in parts[:3]:
+            if part in _X or part == "":
+                raise ValueError("not a concrete version: %s" % text)
+            nums.append(int(part))
+        while len(nums) < 3:
+            nums.append(0)
+        self.major, self.minor, self.patch = nums
+        self.prerelease = tuple(pre.split(".")) if pre else None
+
+    def tuple(self):
+        return (self.major, self.minor, self.patch)
+
+    def __str__(self):
+        core = "%d.%d.%d" % (self.major, self.minor, self.patch)
+        if self.prerelease:
+            return core + "-" + ".".join(self.prerelease)
+        return core
+
+    def __eq__(self, other):
+        return self.tuple() == other.tuple() and self.prerelease == other.prerelease
+
+    def __lt__(self, other):
+        if self.tuple() != other.tuple():
+            return self.tuple() < other.tuple()
+        if self.prerelease is None and other.prerelease is None:
+            return False
+        if self.prerelease is None:
+            return False
+        if other.prerelease is None:
+            return True
+        return _cmp_pre_ids(self.prerelease, other.prerelease) < 0
+
+    def __le__(self, other):
+        return self == other or self < other
+
+    def __gt__(self, other):
+        return other < self
+
+    def __ge__(self, other):
+        return self == other or self > other
+
+
+def _parse_partial(text):
+    """Return (major, minor, patch, wild_at) where wild_at is 0/1/2/3 (3=exact)."""
+    raw = text.strip()
+    if raw.startswith("v") or raw.startswith("V"):
+        raw = raw[1:]
+    if "+" in raw:
+        raw = raw.split("+", 1)[0]
+    if "-" in raw:
+        raw = raw.split("-", 1)[0]
+    if raw in _X or raw == "":
+        return (0, 0, 0, 0)
+    parts = raw.split(".")
+    nums = []
+    wild_at = 3
+    for i, part in enumerate(parts[:3]):
+        if part in _X:
+            wild_at = i
+            break
+        nums.append(int(part))
+    else:
+        wild_at = len(nums)
+        if wild_at > 3:
+            wild_at = 3
+    while len(nums) < 3:
+        nums.append(0)
+    return (nums[0], nums[1], nums[2], wild_at)
+
+
+def _caret_bounds(ver):
+    lower = ver
+    if ver.major != 0:
+        upper = Version("%d.0.0" % (ver.major + 1))
+    elif ver.minor != 0:
+        upper = Version("0.%d.0" % (ver.minor + 1))
+    else:
+        upper = Version("0.0.%d" % (ver.patch + 1))
+    return lower, upper
+
+
+def _tilde_bounds(major, minor, patch, wild_at):
+    lower = Version("%d.%d.%d" % (major, minor, patch))
+    if wild_at <= 1:
+        upper = Version("%d.0.0" % (major + 1))
+    else:
+        upper = Version("%d.%d.0" % (major, minor + 1))
+    return lower, upper
+
+
+def _split_comparators(clause):
+    """Split a single ||-clause into tokens, keeping hyphen ranges together."""
+    clause = clause.strip()
+    if not clause or clause == "*":
+        return ["*"]
+    hyphen = re.match(r"^(.+?)\s+-\s+(.+)$", clause)
+    if hyphen:
+        return [">=" + hyphen.group(1).strip(), "<=" + hyphen.group(2).strip()]
+    return clause.split()
+
+
+def _token_to_bounds(token):
+    """Return list of (op, Version) with op in >=, <, <=, >, =, *."""
+    token = token.strip()
+    if token in ("*", "", "x", "X"):
+        return [("*", None)]
+    if token.startswith("^"):
+        partial = token[1:]
+        pre = None
+        core = partial
+        if "-" in partial.split("+", 1)[0]:
+            core, pre_s = partial.split("+", 1)[0].split("-", 1)
+            pre = tuple(pre_s.split("."))
+        major, minor, patch, wild_at = _parse_partial(core)
+        ver = Version("%d.%d.%d" % (major, minor, patch))
+        ver.prerelease = pre
+        if wild_at == 0:
+            return [("*", None)]
+        if wild_at == 1:
+            return [(">=", Version("%d.0.0" % major)), ("<", Version("%d.0.0" % (major + 1)))]
+        lower, upper = _caret_bounds(ver)
+        return [(">=", lower), ("<", upper)]
+    if token.startswith("~"):
+        major, minor, patch, wild_at = _parse_partial(token[1:])
+        if wild_at == 0:
+            return [("*", None)]
+        lower, upper = _tilde_bounds(major, minor, patch, wild_at)
+        return [(">=", lower), ("<", upper)]
+    m = re.match(r"^(>=|<=|>|<|=)?\s*(.+)$", token)
+    if not m:
+        raise ValueError("bad range token: %s" % token)
+    op = m.group(1) or "="
+    rest = m.group(2).strip()
+    major, minor, patch, wild_at = _parse_partial(rest)
+    if wild_at < 3 and op == "=":
+        if wild_at == 0:
+            return [("*", None)]
+        if wild_at == 1:
+            return [
+                (">=", Version("%d.0.0" % major)),
+                ("<", Version("%d.0.0" % (major + 1))),
+            ]
+        return [
+            (">=", Version("%d.%d.0" % (major, minor))),
+            ("<", Version("%d.%d.0" % (major, minor + 1))),
+        ]
+    ver = Version("%d.%d.%d" % (major, minor, patch))
+    if "-" in rest.split("+", 1)[0]:
+        pre = rest.split("+", 1)[0].split("-", 1)[1]
+        ver.prerelease = tuple(pre.split("."))
+    return [(op, ver)]
+
+
+def _cmp_op(version, op, bound):
+    if op == "*":
+        return True
+    if op == "=":
+        return version == bound
+    if op == ">=":
+        return version >= bound
+    if op == ">":
+        return version > bound
+    if op == "<=":
+        return version <= bound
+    if op == "<":
+        return version < bound
+    raise ValueError("unknown op %s" % op)
+
+
+def _clause_allows_prerelease(comparators):
+    for op, bound in comparators:
+        if bound is not None and bound.prerelease:
+            return True
+    return False
+
+
+def satisfies(version_text, spec):
+    try:
+        version = Version(version_text)
+    except (TypeError, ValueError):
+        return False
+    spec = (spec or "*").strip()
+    if spec in ("*", "", "x", "X"):
+        return version.prerelease is None
+    for clause in spec.split("||"):
+        try:
+            tokens = _split_comparators(clause)
+            comparators = []
+            for token in tokens:
+                comparators.extend(_token_to_bounds(token))
+        except (TypeError, ValueError):
+            continue
+        allow_pre = _clause_allows_prerelease(comparators)
+        if version.prerelease and not allow_pre:
+            continue
+        if all(_cmp_op(version, op, bound) for op, bound in comparators):
+            return True
+    return False
+
+
+def max_satisfying(versions, spec):
+    matching = []
+    for item in versions:
+        if satisfies(item, spec):
+            try:
+                matching.append((Version(item), item))
+            except (TypeError, ValueError):
+                continue
+    if not matching:
+        return None
+    matching.sort(key=lambda pair: pair[0])
+    return matching[-1][1]
+
+
+def is_registry_spec(spec):
+    if spec is None:
+        return False
+    stripped = spec.strip()
+    if not stripped:
+        return False
+    prefixes = (
+        "http://",
+        "https://",
+        "git+",
+        "git://",
+        "file:",
+        "github:",
+        "workspace:",
+        "npm:",
+        "link:",
+        "portal:",
+    )
+    lower = stripped.lower()
+    return not lower.startswith(prefixes)
 
 
 def pkg_path(name):
@@ -36,42 +317,14 @@ def get_json(url):
         return json.load(resp)
 
 
-def main(argv):
-    if len(argv) != 4:
-        print(
-            "Usage: lookup-npm-tl-compliance <registry-base-url> <name> <version>",
-            file=sys.stderr,
-        )
-        return 2
+def resolve_from_packument(data, spec):
+    versions = list((data.get("versions") or {}).keys())
+    if spec in (data.get("versions") or {}):
+        return spec
+    return max_satisfying(versions, spec)
 
-    registry, name, version = argv[1], argv[2], argv[3]
-    registry = registry.rstrip("/")
-    meta_url = "%s/%s" % (registry, pkg_path(name))
 
-    try:
-        data = get_json(meta_url)
-    except urllib.error.HTTPError as exc:
-        if exc.code == 404:
-            return 1
-        print(
-            "[lookup-npm-tl-compliance] registry error %s for %s" % (exc.code, meta_url),
-            file=sys.stderr,
-        )
-        return 2
-    except Exception as exc:
-        print(
-            "[lookup-npm-tl-compliance] registry request failed for %s: %s"
-            % (meta_url, exc),
-            file=sys.stderr,
-        )
-        return 2
-
-    versions = data.get("versions") or {}
-    if version not in versions:
-        return 1
-
-    # Adjacent compliance sidecar when release has published it:
-    # express@5.2.1 → .../express/-/express-5.2.1.tl-compliance.json
+def compliance_for_version(registry, name, version):
     short = name.split("/")[-1]
     comp_url = "%s/%s/-/%s-%s.tl-compliance.json" % (
         registry,
@@ -83,8 +336,7 @@ def main(argv):
         comp = get_json(comp_url)
         level = comp.get("compliance_level")
         if level in ("L1", "L2", "L3"):
-            print(level)
-            return 0
+            return 0, level
     except urllib.error.HTTPError as exc:
         if exc.code not in (404, 301, 302):
             print(
@@ -92,12 +344,79 @@ def main(argv):
                 % (exc.code, comp_url),
                 file=sys.stderr,
             )
-            return 2
+            return 2, None
     except Exception:
         pass
-
     # On registry, no compliance record yet → bootstrap L3.
-    print("L3")
+    return 0, "L3"
+
+
+def lookup(registry, name, spec):
+    registry = registry.rstrip("/")
+    if not is_registry_spec(spec):
+        return 1, None
+    meta_url = "%s/%s" % (registry, pkg_path(name))
+    try:
+        data = get_json(meta_url)
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return 1, None
+        print(
+            "[lookup-npm-tl-compliance] registry error %s for %s" % (exc.code, meta_url),
+            file=sys.stderr,
+        )
+        return 2, None
+    except Exception as exc:
+        print(
+            "[lookup-npm-tl-compliance] registry request failed for %s: %s"
+            % (meta_url, exc),
+            file=sys.stderr,
+        )
+        return 2, None
+
+    resolved = resolve_from_packument(data, spec)
+    if resolved is None:
+        return 1, None
+    rc, level = compliance_for_version(registry, name, resolved)
+    if rc != 0:
+        return rc, None
+    payload = {
+        "name": name,
+        "requested": spec,
+        "version": resolved,
+        "compliance_level": level,
+    }
+    return 0, payload
+
+
+def main(argv):
+    if len(argv) >= 2 and argv[1] == "--max-satisfying":
+        if len(argv) < 3:
+            print(
+                "Usage: lookup-npm-tl-compliance --max-satisfying <spec> [version ...]",
+                file=sys.stderr,
+            )
+            return 2
+        spec = argv[2]
+        versions = argv[3:]
+        found = max_satisfying(versions, spec)
+        if found is None:
+            return 1
+        print(found)
+        return 0
+
+    if len(argv) != 4:
+        print(
+            "Usage: lookup-npm-tl-compliance <registry-base-url> <name> <version-or-range>",
+            file=sys.stderr,
+        )
+        return 2
+
+    registry, name, spec = argv[1], argv[2], argv[3]
+    rc, payload = lookup(registry, name, spec)
+    if rc != 0:
+        return rc
+    print(json.dumps(payload, separators=(",", ":")))
     return 0
 
 

--- a/npm-builder/tests/run_tests.sh
+++ b/npm-builder/tests/run_tests.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Unit tests for npm-builder compliance helpers.
+# Run from repo:  ./npm-builder/tests/run_tests.sh
+# Or via Containerfile test stage.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# assess-npm-compliance needs bash 4+ (mapfile) and GNU sha256sum.
+for b in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+    if [[ -x "${b}" ]]; then
+        export PATH="$(dirname "${b}"):${PATH}"
+        break
+    fi
+done
+for p in /opt/homebrew/opt/coreutils/libexec/gnubin /usr/local/opt/coreutils/libexec/gnubin; do
+    if [[ -x "${p}/sha256sum" ]]; then
+        export PATH="${p}:${PATH}"
+        break
+    fi
+done
+
+python3 "${ROOT}/test_lookup_npm_tl_compliance.py" -v
+bash "${ROOT}/test_assess_npm_compliance.sh"

--- a/npm-builder/tests/test_assess_npm_compliance.sh
+++ b/npm-builder/tests/test_assess_npm_compliance.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Fixture tests for assess-npm-compliance.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPTS="${ROOT}/scripts"
+export PATH="${SCRIPTS}:${PATH}"
+
+# Prefer bash 4+ / GNU sha256sum when testing from a Mac checkout.
+for b in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+    if [[ -x "${b}" ]]; then
+        export PATH="$(dirname "${b}"):${PATH}"
+        break
+    fi
+done
+for p in /opt/homebrew/opt/coreutils/libexec/gnubin /usr/local/opt/coreutils/libexec/gnubin; do
+    if [[ -x "${p}/sha256sum" ]]; then
+        export PATH="${p}:${PATH}"
+        break
+    fi
+done
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local got="$1" want="$2" msg="$3"
+    if [[ "${got}" == "${want}" ]]; then
+        echo "PASS: ${msg}"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: ${msg} (got='${got}' want='${want}')" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+pack_tgz() {
+    local dest="$1"
+    local name="$2"
+    local version="$3"
+    local deps_json="$4"
+    local dir
+    dir="$(mktemp -d "${TMPDIR:-/tmp}/assess-pack.XXXXXX")"
+    mkdir -p "${dir}/package"
+    jq -n --arg name "${name}" --arg version "${version}" --argjson deps "${deps_json}" \
+        '{name:$name, version:$version, dependencies:$deps}' \
+        > "${dir}/package/package.json"
+    tar -czf "${dest}" -C "${dir}" package
+    rm -rf "${dir}"
+}
+
+write_manifest() {
+    local path="$1"
+    local name="$2"
+    local version="$3"
+    mkdir -p "$(dirname "${path}")"
+    jq -n --arg name "${name}" --arg version "${version}" \
+        '{
+          name: $name,
+          version: $version,
+          native_tier: "A",
+          source: {url: "https://example.test/repo.git", ref: ("v" + $version)},
+          entrypoint: "build.entrypoint.sh",
+          smoke: "verify.smoke.sh",
+          outputs: [{id:"main", type:"npm-package", path:("out/" + $name + "-" + $version + ".tgz"), pulp_name: $name}]
+        }' > "${path}"
+}
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/assess-npm.XXXXXX")"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+# --- leaf, no dependencies → L3 ---
+leaf_root="${tmpdir}/leaf"
+mkdir -p "${leaf_root}/artifact" "${leaf_root}/source/packages/leaf/1.0.0"
+pack_tgz "${leaf_root}/artifact/leaf-1.0.0.tgz" "leaf" "1.0.0" '{}'
+write_manifest "${leaf_root}/source/packages/leaf/1.0.0/manifest.json" "leaf" "1.0.0"
+assess-npm-compliance "${leaf_root}/artifact" "${leaf_root}/source" "packages/leaf/1.0.0" \
+    >/dev/null
+assert_eq "$(jq -r .compliance_level "${leaf_root}/artifact/leaf-1.0.0.tl-compliance.json")" \
+    "L3" "no packed dependencies → L3"
+assert_eq "$(jq -r '.direct_dependencies | length' "${leaf_root}/artifact/leaf-1.0.0.tl-compliance.json")" \
+    "0" "no packed dependencies → empty direct_dependencies"
+
+# Mock registry lookups: missing vs present L3.
+mock_bin="${tmpdir}/bin"
+mkdir -p "${mock_bin}"
+cat > "${mock_bin}/lookup-npm-tl-compliance" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "--max-satisfying" ]]; then
+  exec "$(command -v lookup-npm-tl-compliance.real)" "$@"
+fi
+# registry mode
+name="$2"
+spec="$3"
+case "${name}" in
+  missing)
+    exit 1
+    ;;
+  present)
+    jq -nc --arg name "${name}" --arg requested "${spec}" \
+      '{name:$name, requested:$requested, version:"1.0.0", compliance_level:"L3"}'
+    exit 0
+    ;;
+  mid)
+    jq -nc --arg name "${name}" --arg requested "${spec}" \
+      '{name:$name, requested:$requested, version:"1.0.0", compliance_level:"L2"}'
+    exit 0
+    ;;
+  *)
+    echo "unexpected lookup ${name}" >&2
+    exit 2
+    ;;
+esac
+EOF
+chmod +x "${mock_bin}/lookup-npm-tl-compliance"
+cp "${SCRIPTS}/lookup-npm-tl-compliance" "${mock_bin}/lookup-npm-tl-compliance.real"
+chmod +x "${mock_bin}/lookup-npm-tl-compliance.real"
+export PATH="${mock_bin}:${SCRIPTS}:${PATH}"
+
+# --- missing dep → L1 ---
+miss_root="${tmpdir}/miss"
+mkdir -p "${miss_root}/artifact" "${miss_root}/source/packages/parent/1.0.0"
+pack_tgz "${miss_root}/artifact/parent-1.0.0.tgz" "parent" "1.0.0" '{"missing":"^1.0.0"}'
+write_manifest "${miss_root}/source/packages/parent/1.0.0/manifest.json" "parent" "1.0.0"
+assess-npm-compliance "${miss_root}/artifact" "${miss_root}/source" "packages/parent/1.0.0" \
+    >/dev/null
+assert_eq "$(jq -r .compliance_level "${miss_root}/artifact/parent-1.0.0.tl-compliance.json")" \
+    "L1" "packed dep missing from TL → L1"
+assert_eq "$(jq -r '.closure_gaps[0].name' "${miss_root}/artifact/parent-1.0.0.tl-compliance.json")" \
+    "missing" "gap records packed dep name"
+
+# --- dep on TL at L3 → L3 ---
+ok_root="${tmpdir}/ok"
+mkdir -p "${ok_root}/artifact" "${ok_root}/source/packages/parent/1.0.0"
+pack_tgz "${ok_root}/artifact/parent-1.0.0.tgz" "parent" "1.0.0" '{"present":"^1.0.0"}'
+write_manifest "${ok_root}/source/packages/parent/1.0.0/manifest.json" "parent" "1.0.0"
+assess-npm-compliance "${ok_root}/artifact" "${ok_root}/source" "packages/parent/1.0.0" \
+    >/dev/null
+assert_eq "$(jq -r .compliance_level "${ok_root}/artifact/parent-1.0.0.tl-compliance.json")" \
+    "L3" "packed dep on TL at L3 → L3"
+assert_eq "$(jq -r '.direct_dependencies[0].version' "${ok_root}/artifact/parent-1.0.0.tl-compliance.json")" \
+    "1.0.0" "sidecar records resolved version"
+
+# --- dep on TL at L2 → L2 ---
+mid_root="${tmpdir}/mid"
+mkdir -p "${mid_root}/artifact" "${mid_root}/source/packages/parent/1.0.0"
+pack_tgz "${mid_root}/artifact/parent-1.0.0.tgz" "parent" "1.0.0" '{"mid":"^1.0.0"}'
+write_manifest "${mid_root}/source/packages/parent/1.0.0/manifest.json" "parent" "1.0.0"
+assess-npm-compliance "${mid_root}/artifact" "${mid_root}/source" "packages/parent/1.0.0" \
+    >/dev/null
+assert_eq "$(jq -r .compliance_level "${mid_root}/artifact/parent-1.0.0.tl-compliance.json")" \
+    "L2" "packed dep on TL at L2 → L2"
+
+# --- same-OCI dep: parent waits for leaf sidecar ---
+local_root="${tmpdir}/local"
+mkdir -p "${local_root}/artifact" \
+    "${local_root}/source/packages/leaf/1.0.0" \
+    "${local_root}/source/packages/parent/1.0.0"
+pack_tgz "${local_root}/artifact/leaf-1.0.0.tgz" "leaf" "1.0.0" '{}'
+pack_tgz "${local_root}/artifact/parent-1.0.0.tgz" "parent" "1.0.0" '{"leaf":"^1.0.0"}'
+write_manifest "${local_root}/source/packages/leaf/1.0.0/manifest.json" "leaf" "1.0.0"
+write_manifest "${local_root}/source/packages/parent/1.0.0/manifest.json" "parent" "1.0.0"
+assess-npm-compliance "${local_root}/artifact" "${local_root}/source" \
+    "packages/parent/1.0.0" "packages/leaf/1.0.0" >/dev/null
+assert_eq "$(jq -r .compliance_level "${local_root}/artifact/leaf-1.0.0.tl-compliance.json")" \
+    "L3" "same-OCI leaf → L3"
+assert_eq "$(jq -r .compliance_level "${local_root}/artifact/parent-1.0.0.tl-compliance.json")" \
+    "L3" "parent of same-OCI L3 leaf → L3"
+assert_eq "$(jq -r '.direct_dependencies[0].version' "${local_root}/artifact/parent-1.0.0.tl-compliance.json")" \
+    "1.0.0" "parent resolved leaf from this snapshot"
+
+echo
+echo "assess-npm-compliance: ${PASS} passed, ${FAIL} failed"
+[[ "${FAIL}" -eq 0 ]]

--- a/npm-builder/tests/test_lookup_npm_tl_compliance.py
+++ b/npm-builder/tests/test_lookup_npm_tl_compliance.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Unit tests for lookup-npm-tl-compliance (semver + mocked registry)."""
+from __future__ import print_function
+
+import importlib.machinery
+import importlib.util
+import io
+import json
+import os
+import sys
+import unittest
+import urllib.error
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SCRIPT = os.path.join(ROOT, "scripts", "lookup-npm-tl-compliance")
+
+_loader = importlib.machinery.SourceFileLoader("lookup_npm_tl_compliance", SCRIPT)
+_spec = importlib.util.spec_from_loader(_loader.name, _loader)
+lookup = importlib.util.module_from_spec(_spec)
+sys.dont_write_bytecode = True
+_loader.exec_module(lookup)
+
+
+class FakeHTTPError(urllib.error.HTTPError):
+    def __init__(self, url, code):
+        hdrs = {}
+        fp = io.BytesIO()
+        urllib.error.HTTPError.__init__(self, url, code, "err", hdrs, fp)
+
+
+class SemverTests(unittest.TestCase):
+    def test_exact(self):
+        self.assertTrue(lookup.satisfies("1.5.0", "1.5.0"))
+        self.assertFalse(lookup.satisfies("1.5.1", "1.5.0"))
+
+    def test_caret(self):
+        self.assertTrue(lookup.satisfies("1.5.0", "^1.5.0"))
+        self.assertTrue(lookup.satisfies("1.9.9", "^1.5.0"))
+        self.assertFalse(lookup.satisfies("2.0.0", "^1.5.0"))
+        self.assertTrue(lookup.satisfies("0.2.5", "^0.2.3"))
+        self.assertFalse(lookup.satisfies("0.3.0", "^0.2.3"))
+        self.assertTrue(lookup.satisfies("0.0.3", "^0.0.3"))
+        self.assertFalse(lookup.satisfies("0.0.4", "^0.0.3"))
+
+    def test_tilde(self):
+        self.assertTrue(lookup.satisfies("1.2.3", "~1.2.3"))
+        self.assertTrue(lookup.satisfies("1.2.9", "~1.2.3"))
+        self.assertFalse(lookup.satisfies("1.3.0", "~1.2.3"))
+        self.assertTrue(lookup.satisfies("1.2.0", "~1.2"))
+        self.assertFalse(lookup.satisfies("1.3.0", "~1.2"))
+
+    def test_star_and_x(self):
+        self.assertTrue(lookup.satisfies("1.2.3", "*"))
+        self.assertTrue(lookup.satisfies("1.2.3", "1.x"))
+        self.assertFalse(lookup.satisfies("2.0.0", "1.x"))
+        self.assertTrue(lookup.satisfies("1.2.9", "1.2.x"))
+        self.assertFalse(lookup.satisfies("1.3.0", "1.2.x"))
+
+    def test_comparators_and_or(self):
+        self.assertTrue(lookup.satisfies("1.5.0", ">=1.0.0 <2.0.0"))
+        self.assertFalse(lookup.satisfies("2.0.0", ">=1.0.0 <2.0.0"))
+        self.assertTrue(lookup.satisfies("2.1.0", "^1.0.0 || ^2.0.0"))
+
+    def test_prerelease_skipped_by_default(self):
+        self.assertFalse(lookup.satisfies("1.5.0-beta.1", "^1.5.0"))
+        self.assertTrue(lookup.satisfies("1.5.0-beta.1", "^1.5.0-beta.1"))
+
+    def test_max_satisfying_picks_highest(self):
+        self.assertEqual(
+            lookup.max_satisfying(["1.4.0", "1.5.2", "1.5.0", "2.0.0"], "^1.5.0"),
+            "1.5.2",
+        )
+        self.assertIsNone(lookup.max_satisfying(["2.0.0"], "^1.5.0"))
+
+    def test_registry_spec(self):
+        self.assertTrue(lookup.is_registry_spec("^1.5.0"))
+        self.assertFalse(lookup.is_registry_spec("git+https://example.com/repo.git"))
+        self.assertFalse(lookup.is_registry_spec("https://example.com/foo.tgz"))
+
+
+class LookupTests(unittest.TestCase):
+    def setUp(self):
+        self.orig = lookup.get_json
+        self.urls = []
+
+    def tearDown(self):
+        lookup.get_json = self.orig
+
+    def _install(self, handler):
+        def wrapped(url):
+            self.urls.append(url)
+            return handler(url)
+
+        lookup.get_json = wrapped
+
+    def test_exact_hit_with_sidecar(self):
+        def handler(url):
+            if url.endswith("/bindings"):
+                return {"versions": {"1.5.0": {}, "1.5.5": {}}}
+            if url.endswith("bindings-1.5.0.tl-compliance.json"):
+                return {"compliance_level": "L2"}
+            raise FakeHTTPError(url, 404)
+
+        self._install(handler)
+        rc, payload = lookup.lookup("https://example.test/javascript", "bindings", "1.5.0")
+        self.assertEqual(rc, 0)
+        self.assertEqual(payload["version"], "1.5.0")
+        self.assertEqual(payload["compliance_level"], "L2")
+
+    def test_range_picks_highest_and_bootstraps_l3(self):
+        def handler(url):
+            if url.endswith("/bindings"):
+                return {"versions": {"1.5.0": {}, "1.5.5": {}, "2.0.0": {}}}
+            raise FakeHTTPError(url, 404)
+
+        self._install(handler)
+        rc, payload = lookup.lookup("https://example.test/javascript", "bindings", "^1.5.0")
+        self.assertEqual(rc, 0)
+        self.assertEqual(payload["version"], "1.5.5")
+        self.assertEqual(payload["compliance_level"], "L3")
+        self.assertEqual(payload["requested"], "^1.5.0")
+
+    def test_missing_package(self):
+        def handler(url):
+            raise FakeHTTPError(url, 404)
+
+        self._install(handler)
+        rc, payload = lookup.lookup("https://example.test/javascript", "missing", "^1.0.0")
+        self.assertEqual(rc, 1)
+        self.assertIsNone(payload)
+
+    def test_range_unsatisfied(self):
+        def handler(url):
+            if url.endswith("/bindings"):
+                return {"versions": {"2.0.0": {}}}
+            raise FakeHTTPError(url, 404)
+
+        self._install(handler)
+        rc, payload = lookup.lookup("https://example.test/javascript", "bindings", "^1.5.0")
+        self.assertEqual(rc, 1)
+        self.assertIsNone(payload)
+
+    def test_git_spec_is_a_miss(self):
+        rc, payload = lookup.lookup(
+            "https://example.test/javascript",
+            "foo",
+            "git+https://github.com/x/y.git",
+        )
+        self.assertEqual(rc, 1)
+        self.assertIsNone(payload)
+
+    def test_scoped_packument_path(self):
+        self.assertIn("%2F", lookup.pkg_path("@calunga/esbuild-linux-x64"))
+
+    def test_main_max_satisfying_cli(self):
+        buf = io.StringIO()
+        old = sys.stdout
+        sys.stdout = buf
+        try:
+            rc = lookup.main(
+                ["lookup-npm-tl-compliance", "--max-satisfying", "^1.5.0", "1.4.0", "1.5.1"]
+            )
+        finally:
+            sys.stdout = old
+        self.assertEqual(rc, 0)
+        self.assertEqual(buf.getvalue().strip(), "1.5.1")
+
+    def test_main_json_stdout(self):
+        def handler(url):
+            if url.endswith("/bindings"):
+                return {"versions": {"1.5.0": {}}}
+            raise FakeHTTPError(url, 404)
+
+        self._install(handler)
+        buf = io.StringIO()
+        old = sys.stdout
+        sys.stdout = buf
+        try:
+            rc = lookup.main(
+                [
+                    "lookup-npm-tl-compliance",
+                    "https://example.test/javascript",
+                    "bindings",
+                    "^1.5.0",
+                ]
+            )
+        finally:
+            sys.stdout = old
+        self.assertEqual(rc, 0)
+        payload = json.loads(buf.getvalue())
+        self.assertEqual(payload["version"], "1.5.0")
+        self.assertEqual(payload["compliance_level"], "L3")
+
+
+class TmpSidecar(unittest.TestCase):
+    """Sanity: script file is executable-shaped (shebang)."""
+
+    def test_shebang(self):
+        with open(SCRIPT) as fh:
+            self.assertTrue(fh.readline().startswith("#!"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tasks/promote-npm-oci-ta.yaml
+++ b/tasks/promote-npm-oci-ta.yaml
@@ -37,7 +37,8 @@ spec:
       type: string
     - name: PACKAGES
       description: >-
-        Package directories whose manifests supply requires_tl_packages
+        Package directories in this promote (manifests group outputs / built_from;
+        packed package.json dependencies are the compliance input)
         (e.g. ["packages/express/5.2.1"])
       type: array
     - name: PACKAGES_STATUS


### PR DESCRIPTION
Assisted-By: Cursor 3.15.6

Right now compliance checks against a field in manifest during on-board. This will require a human to check it matches the real dependencies in package.json. Removing that field from manifest and check directly against packages.json in the assess compliance logic. This will simplify the on-boarding checklist.

## Summary by Sourcery

Derive npm compliance from the dependencies shipped in package archives and gate image creation on automated compliance tests.

New Features:
- Assess npm compliance directly from dependencies declared in each packed package.json, including same-OCI dependency resolution and registry version-range lookups.
- Add a live Pulp API probe for validating npm package uploads and compliance labels.

Bug Fixes:
- Ensure compliance results reflect the dependencies actually shipped in the npm archive rather than potentially stale manifest metadata.

Enhancements:
- Extend npm compliance lookup to support packument-based version and range resolution with semver handling.
- Document the updated compliance inputs and local test workflow.

Build:
- Run npm-builder unit tests as a required Containerfile build stage before producing the final image.

Documentation:
- Update promote task metadata and npm-builder documentation to describe packed package.json dependencies as the compliance source.

Tests:
- Add coverage for semver resolution, registry lookup behavior, compliance assessment levels, missing dependencies, and same-OCI dependencies.